### PR TITLE
Fixed a problem, which caused the Angular compiler to report errors

### DIFF
--- a/virelay/frontend/tsconfig.app.json
+++ b/virelay/frontend/tsconfig.app.json
@@ -15,5 +15,8 @@
     "exclude": [
         "src/test.ts",
         "src/**/*.spec.ts"
-    ]
+    ],
+    "angularCompilerOptions": {
+      "enableIvy": false
+    }
 }


### PR DESCRIPTION
Fixed a problem, which caused the Angular compiler to report errors that were not actually there. This was due to Angular Ivy being enabled, which was probably introduced by a minor upgrade in some package after doing a fresh clone and `npm install`.