### PR TITLE
Docs: Fix docstring in model & server

### DIFF
--- a/virelay/model.py
+++ b/virelay/model.py
@@ -168,8 +168,8 @@ class Project:
         """
         Retrieves the names of the categories that are in the analyses of the specified analysis method.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
             analysis_method: str
                 The name of the analysis method for which the categories are to be retrieved.
 
@@ -199,8 +199,8 @@ class Project:
         """
         Retrieves the names of the clustering methods that are in the analyses of the specified analysis method.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
             analysis_method: str
                 The name of the analysis method for which the clusterings are to be retrieved.
 
@@ -224,8 +224,8 @@ class Project:
         """
         Retrieves the names of the embedding methods that are in the analyses of the specified analysis method.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
             analysis_method: str
                 The name of the analysis method for which the embeddings are to be retrieved.
 

--- a/virelay/server.py
+++ b/virelay/server.py
@@ -657,6 +657,7 @@ class Server:
                 The exception that is to be formatted.
 
         Returns
+        -------
             str
                 Returns a string, which contains the error message of the exception. If the server is being run in debug
                 mode, then the traceback is also included in the string that is returned.


### PR DESCRIPTION
- model and server had some problems in their docstrings
- in `model.py`: `Parameter` instead of `Parameters` in 3 instances
- in `server.py`: `Returns` missing `-------` in 1 instance