### PR TITLE
Tox: More python versions and building docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,62 @@
 [tox]
-skip_missing_interpreters = True
-envlist = py38,pylint,flake8
+skip_missing_interpreters = true
+envlist = py37,py38,py39,pylint,flake8,docs
+
+[testenv]
+deps =
+   pytest
+   pytest-cov
+setenv =
+    COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
+commands =
+    pytest \
+        --cov "{envsitepackagesdir}/virelay" \
+        --cov-config "{toxinidir}/tox.ini" \
+        {posargs:.}
+
+[testenv:coverage]
+deps =
+   coverage
+setenv =
+    COVERAGE_FILE = {toxworkdir}/.coverage
+skip_install = true
+commands =
+    coverage combine
+    coverage report -m
+depends = py37,py38,py39
+
+[testenv:docs]
+basepython = python3.9
+deps =
+    -r {toxinidir}/docs/requirements.txt
+commands =
+    sphinx-build \
+        --color \
+        -W \
+        --keep-going \
+        -d "{toxinidir}/docs/doctree" \
+        -b html \
+        "{toxinidir}/docs/source" \
+        "{toxinidir}/docs/build" \
+        {posargs}
+
+[testenv:flake8]
+basepython = python3.9
+changedir = {toxinidir}
+deps =
+    flake8
+commands =
+    flake8 "{toxinidir}/virelay" "{toxinidir}/tests" {posargs}
+
+
+[testenv:pylint]
+basepython = python3.9
+deps =
+    pylint
+    pytest
+changedir = {toxinidir}
+commands =
+    pylint --rcfile=pylintrc --output-format=parseable {toxinidir}/virelay {toxinidir}/tests
 
 [flake8]
 # R0902 Too many instance attributes
@@ -13,27 +69,19 @@ exclude=.venv,.git,.tox,build,dist,docs,*egg,*.ini
 
 max-line-length = 120
 
-[testenv]
-deps =
-   pytest
-   pytest-cov
-setenv =
-    COVERAGE_FILE = {toxinidir}/.coverage.{envname}
-commands =
-    python -m pytest --cov=virelay {toxinidir}/tests/ {posargs:}
-changedir = {toxworkdir}
+[pytest]
+testpaths = tests
+addopts = -ra -l
 
-[testenv:flake8]
-changedir = {toxinidir}
-deps =
-    flake8
-commands =
-    flake8 {toxworkdir} {posargs}
+[coverage:run]
+parallel = true
+branch = true
 
-[testenv:pylint]
-deps =
-    pylint
-    pytest
-changedir = {toxinidir}
-commands =
-    python -m pylint --rcfile=pylintrc --output-format=parseable virelay tests
+[coverage:report]
+skip_covered = true
+show_missing = true
+
+[coverage:paths]
+source = virelay
+    */.tox/*/lib/python*/site-packages/virelay
+    */virelay


### PR DESCRIPTION
- support python 3.7 - 3.9
- move flake8 to bottom, and execute only in py39
- reformat pytest command, add config for coverage
- add docs environment to build docs
- add coverage environment
- make pylint command locations more explicit, execute only in py39
- add pytest configuration
- add coverage configuration