### PR TITLE
Add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,5 @@
+python:
+  version: "3.8"
+  install:
+    - method: pip
+      path: .


### PR DESCRIPTION
- needed to correctly install the virelay module during the build of the
  docs