### PR TITLE
Configure readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+sphinx:
+  configuration: docs/source/conf.py
+
 python:
-  version: "3.8"
   install:
+    - requirements: docs/requirements.txt
     - method: pip
       path: .


### PR DESCRIPTION
- move the current configuration from the rtd-interface to the config
- add necessary version
- this fixes linkcode not working properly