### PR TITLE
Fixed code smells in the backend and frontend

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -234,7 +234,7 @@ class TestServer:
         assert attribution['urls']['jet'] == '/api/projects/0/dataset/0/image'
         assert attribution['urls']['seismic'] == '/api/projects/0/dataset/0/image'
 
-        http_response = test_client.get('/api/projects/0/attributions/0?image_mode=attribution')
+        http_response = test_client.get('/api/projects/0/attributions/0?imageMode=attribution')
         assert http_response.status_code == 200
         assert http_response.content_type == 'application/json'
         attribution = http_response.get_json()
@@ -260,7 +260,7 @@ class TestServer:
         assert attribution['urls']['seismic'] == \
             '/api/projects/0/attributions/0/heatmap?colorMap=seismic&superimpose=False'
 
-        http_response = test_client.get('/api/projects/0/attributions/0?image_mode=overlay')
+        http_response = test_client.get('/api/projects/0/attributions/0?imageMode=overlay')
         assert http_response.status_code == 200
         assert http_response.content_type == 'application/json'
         attribution = http_response.get_json()

--- a/virelay/application.py
+++ b/virelay/application.py
@@ -9,7 +9,7 @@ from .model import Workspace
 
 
 def create_app(projects=None):
-    """Create an application in a way understood by gunicorn etc."""
+    """Create an application in a way understood by Gunicorn etc."""
 
     if projects is None:
         try:
@@ -71,9 +71,9 @@ class Application:
             action='store_true',
             help='''
                 Determines whether the application is run in debug mode. When the application is in debug mode, all
-                FLASK and Werkzeug logs are printed to stdout, FLASK debugging is activated (FLASK will print out the
+                Flask and Werkzeug logs are printed to stdout, Flask debugging is activated (Flask will print out the
                 debugger PIN for attaching the debugger), and automatic reloading (when files change) is activated.
-                Furthermore, the frontend of the application will not be served by flask and instead has to be served
+                Furthermore, the frontend of the application will not be served by Flask and instead has to be served
                 externally (e.g. via ng serve).
             '''
         )
@@ -91,12 +91,12 @@ class Application:
         for project_path in arguments.project:
             self.workspace.add_project(project_path)
 
-        # Registers the cleanup method, which will be called when the application is quit (the FLASK server is long
+        # Registers the cleanup method, which will be called when the application is quit (the Flask server is long
         # running and will only exit when the user sends a signal, e.g. via Ctrl+C, to stop the process, atexit
-        # registers a callback, which is exected, when the Python interpreter is shut down)
+        # registers a callback, which is executed, when the Python interpreter is shut down)
         atexit.register(self.shutdown)
 
-        # Creates the FLASK server, which serves the frontend website as well as the RESTful API
+        # Creates the Flask server, which serves the frontend website as well as the RESTful API
         server = Server(self.workspace, arguments.debug_mode)
         server.run(arguments.host, arguments.port)
 

--- a/virelay/frontend/distribution/index.html
+++ b/virelay/frontend/distribution/index.html
@@ -8,6 +8,6 @@
 
     <body>
         <app-root></app-root>
-    <script src="runtime.eb5d8bdf79d24dc8.js" type="module"></script><script src="polyfills.11b988b8addf7c84.js" type="module"></script><script src="scripts.3c038d4d4fa62045.js" defer></script><script src="main.487286ffbc6a5ecc.js" type="module"></script>
+    <script src="runtime.eb5d8bdf79d24dc8.js" type="module"></script><script src="polyfills.11b988b8addf7c84.js" type="module"></script><script src="scripts.3c038d4d4fa62045.js" defer></script><script src="main.0ac9960c851d1795.js" type="module"></script>
 
 </body></html>

--- a/virelay/frontend/src/services/attributions/attributions.service.ts
+++ b/virelay/frontend/src/services/attributions/attributions.service.ts
@@ -30,7 +30,7 @@ export class AttributionsService {
         return await lastValueFrom(this.httpClient
             .get<Attribution>(`${environment.apiBaseUrl}/api/projects/${projectId}/attributions/${index}`, {
                 headers: new HttpHeaders({ 'Content-Type': 'application/json' }),
-                params: new HttpParams().set('image_mode', imageMode)
+                params: new HttpParams().set('imageMode', imageMode)
             })
             .pipe(map(attribution => new Attribution(attribution, environment.apiBaseUrl))));
     }

--- a/virelay/model.py
+++ b/virelay/model.py
@@ -1019,10 +1019,10 @@ class ImageDirectoryDataset:
                 label_word_net_id_regex must be specified.
             input_width: int
                 The width of the input to the model. This is used to resize the dataset samples to the same size as the
-                the model expects its inputs to be.
+                model expects its inputs to be.
             input_height: int
                 The height of the input to the model. This is used to resize the dataset samples to the same size as the
-                the model expects its inputs to be.
+                model expects its inputs to be.
             down_sampling_method: str
                 The method that is to be used to down-sample images from the dataset that are larger than the input to
                 the model.

--- a/virelay/server.py
+++ b/virelay/server.py
@@ -29,11 +29,11 @@ class Server:
                 The workspace that contains the projects that are to be managed by the server.
             is_in_debug_mode: bool
                 Determines whether the application should run in debug mode or not. Defaults to False. When the
-                application is in debug mode, then all FLASK and Werkzeug logs are printed to stdout, FLASK debugging is
-                activated (FLASK will print out the debugger PIN for attaching the debugger), and the automatic
+                application is in debug mode, then all Flask and Werkzeug logs are printed to stdout, Flask debugging is
+                activated (Flask will print out the debugger PIN for attaching the debugger), and the automatic
                 reloading, when the Python files change is activated. Furthermore, the frontend of the application will
                 not be served via the. Otherwise all these things will be deactivated and the frontend of the
-                application is served via the FLASK server. If the application is to be debugged using Visual Studio
+                application is served via the Flask server. If the application is to be debugged using Visual Studio
                 Code (or any other IDE for that matter), then the application must not be started in debug mode, because
                 Visual Studio will create its own debugger.
         """
@@ -54,10 +54,10 @@ class Server:
             'seismic': 'Seismic'
         }
 
-        # Creates the FLASK application
+        # Creates the Flask application
         self.app = flask.Flask('ViRelAy')
 
-        # Registers the routes of the RESTful API with the FLASK application
+        # Registers the routes of the RESTful API with the Flask application
         self.app.add_url_rule(
             '/api/projects',
             'get_projects',
@@ -105,7 +105,7 @@ class Server:
         )
 
         # When the application is not in debug mode, then the Angular frontend is served via the static file serving
-        # feature in FLASK
+        # feature in Flask
         if not self.is_in_debug_mode:
             frontend_path = 'frontend/distribution'
 
@@ -154,7 +154,7 @@ class Server:
 
     def run(self, host='localhost', port=8080):
         """
-        Starts the FLASK server and returns when the application has finished.
+        Starts the Flask server and returns when the application has finished.
 
         Parameters
         ----------
@@ -164,14 +164,14 @@ class Server:
                 The port at which the application should run. Defaults to 8080.
         """
 
-        # If the application is not run in debug mode, then all FLASK and Werkzeug logs are suppressed to make the
+        # If the application is not run in debug mode, then all Flask and Werkzeug logs are suppressed to make the
         # console output a lot cleaner
         if not self.is_in_debug_mode:
             logging.getLogger('werkzeug').disabled = True
             os.environ['WERKZEUG_RUN_MAIN'] = 'true'
 
         # When the application is not in debug mode, then the browser is automatically opened upon application startup
-        # (the problem is, that the FLASK app run() method is blocking, so we cannot start the browser when the app is
+        # (the problem is, that the Flask app run() method is blocking, so we cannot start the browser when the app is
         # run, so we have to set a timer, which will run on a different thread and start the thread after the server,
         # hopefully, has started)
         if not self.is_in_debug_mode:
@@ -182,7 +182,7 @@ class Server:
         if self.is_in_debug_mode:
             flask_cors.CORS(self.app)
 
-        # Starts the FLASK application
+        # Starts the Flask application
         self.app.auto_reload = self.is_in_debug_mode
         self.app.run(host, port, self.is_in_debug_mode)
 
@@ -268,10 +268,11 @@ class Server:
 
         Returns
         -------
-            Returns an HTTP 200 OK response with a JSON string as content, which contains the data of the dataset
-            sample.
-            If the specified project does not exist, then an HTTP 404 Not Found response is returned.
-            If the specified dataset sample does not exist, then an HTTP 404 Not Found response is returned.
+            flask.Response
+                Returns an HTTP 200 OK response with a JSON string as content, which contains the data of the dataset
+                sample.
+                If the specified project does not exist, then an HTTP 404 Not Found response is returned.
+                If the specified dataset sample does not exist, then an HTTP 404 Not Found response is returned.
         """
 
         # Checks if a project with the specified ID exists
@@ -307,9 +308,10 @@ class Server:
 
         Returns
         -------
-            Returns an HTTP 200 OK response with the image of the specified dataset sample as content.
-            If the specified project does not exist, then an HTTP 404 Not Found response is returned.
-            If the specified dataset sample does not exist, then an HTTP 404 Not Found response is returned.
+            flask.Response
+                Returns an HTTP 200 OK response with the image of the specified dataset sample as content.
+                If the specified project does not exist, then an HTTP 404 Not Found response is returned.
+                If the specified dataset sample does not exist, then an HTTP 404 Not Found response is returned.
         """
 
         # Checks if a project with the specified ID exists
@@ -339,9 +341,11 @@ class Server:
 
         Returns
         -------
-            Returns an HTTP 200 OK response with a JSON string as content, which contains the data of the attribution.
-            If the specified project does not exist, then an HTTP 404 Not Found response is returned.
-            If the specified attribution does not exist, then an HTTP 404 Not Found response is returned.
+            flask.Response
+                Returns an HTTP 200 OK response with a JSON string as content, which contains the data of the
+                attribution.
+                If the specified project does not exist, then an HTTP 404 Not Found response is returned.
+                If the specified attribution does not exist, then an HTTP 404 Not Found response is returned.
         """
 
         # Checks if a project with the specified ID exists
@@ -364,7 +368,7 @@ class Server:
             'height': attribution.data.shape[1],
             'urls': {}
         }
-        image_mode = flask.request.args.get('image_mode', 'input')
+        image_mode = flask.request.args.get('imageMode', 'input')
         for color_map in self.color_maps:
             if image_mode in ('overlay', 'attribution'):
                 url = flask.url_for(
@@ -397,9 +401,10 @@ class Server:
 
         Returns
         -------
-            Returns an HTTP 200 OK response with the rendered heatmap image.
-            If the specified project does not exist, then an HTTP 404 Not Found response is returned.
-            If the specified attribution does not exist, then an HTTP 404 Not Found response is returned.
+            flask.Response
+                Returns an HTTP 200 OK response with the rendered heatmap image.
+                If the specified project does not exist, then an HTTP 404 Not Found response is returned.
+                If the specified attribution does not exist, then an HTTP 404 Not Found response is returned.
         """
 
         # Checks if a project with the specified ID exists
@@ -526,7 +531,7 @@ class Server:
 
     def get_color_map_preview(self, color_map):
         """
-        Renders a preview of a color map with a value gradient. Using the URL parameters 'width' and 'height', the size
+        Renders a preview of a color map with a value gradient. Using the URL parameters "width" and "height", the size
         of the preview can be specified. The size defaults to 200x20.
 
         Parameters
@@ -536,8 +541,9 @@ class Server:
 
         Returns
         -------
-            Returns an HTTP 200 OK response with the rendered heatmap preview.
-            If the specified color map is unknown, then an HTTP 400 Bad Request response is returned.
+            flask.Response
+                Returns an HTTP 200 OK response with the rendered heatmap preview.
+                If the specified color map is unknown, then an HTTP 400 Bad Request response is returned.
         """
 
         if color_map not in self.color_maps:


### PR DESCRIPTION
- The image mode parameter of the attributions endpoint of the backend REST API was in snail case (image_mode), but since this is a REST API it should be in camel case (imageMode)
- Fixed multiple spelling mistakes in comments
- References to Flask in comments were all in upper-case (FLASK), but in the official spelling Flask is capitalized (Flask)
- Some server actions were missing the return type in the doc strings