### PR TITLE
Package: Add extra_requires for docs and tests

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,6 @@ sphinx:
 
 python:
   install:
-    - requirements: docs/requirements.txt
     - method: pip
       path: .
+      extra_requirements: ["docs"]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,0 @@
-sphinx-copybutton>=0.4.0
-sphinx-rtd-theme>=1.0.0
-sphinxcontrib.datatemplates>=0.9.0
-sphinxcontrib.bibtex>=2.4.1

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,18 @@ setup(
     setup_requires=[
         'setuptools_scm',
     ],
+    extras_require={
+        'docs': [
+            'sphinx-copybutton>=0.4.0',
+            'sphinx-rtd-theme>=1.0.0',
+            'sphinxcontrib.datatemplates>=0.9.0',
+            'sphinxcontrib.bibtex>=2.4.1',
+        ],
+        'tests': [
+            'pytest',
+            'pytest-cov',
+        ]
+    },
     entry_points={
         'console_scripts': [
             'virelay = virelay.__main__:main',

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,7 @@ skip_missing_interpreters = true
 envlist = py37,py38,py39,pylint,flake8,docs
 
 [testenv]
-deps =
-   pytest
-   pytest-cov
+extras = tests
 setenv =
     COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
 commands =
@@ -27,8 +25,7 @@ depends = py37,py38,py39
 
 [testenv:docs]
 basepython = python3.9
-deps =
-    -r {toxinidir}/docs/requirements.txt
+extras = docs
 commands =
     sphinx-build \
         --color \


### PR DESCRIPTION
- add extra_requires for docs previously specified in
  docs/requirements.txt
- remove docs/requirements.txt
- update .readthedocs.yaml to use the "docs" extra_require
- update the tox.ini for tests and docs to use their respective
  extra_require
- pylint and flake8 do not have their own extra_require, and are
  still specified in tox.ini