### PR TITLE
Examples: Truncate and append meta-analysis

### DIFF
--- a/docs/examples/meta_analysis.py
+++ b/docs/examples/meta_analysis.py
@@ -263,6 +263,10 @@ def meta_analysis(
     if class_indices is None:
         class_indices = [int(label['index']) for label in label_map]
 
+    # Truncate the analysis database
+    print(f'Truncating {analysis_file_path}')
+    h5py.File(analysis_file_path, 'w').close()
+
     # Cycles through all classes and performs the meta-analysis for each of them
     for class_index in class_indices:
 
@@ -280,9 +284,9 @@ def meta_analysis(
         print(f'Computing class {class_name_map[class_index]}')
         (eigenvalues, embedding), (kmeans, dbscan, hdbscan, agglomerative, (umap, tsne)) = pipeline(attribution_data)
 
-        # Saves the meta-analysis to the analysis database
+        # Append the meta-analysis to the analysis database
         print(f'Saving class {class_name_map[class_index]}')
-        with h5py.File(analysis_file_path, 'w') as analysis_file:
+        with h5py.File(analysis_file_path, 'a') as analysis_file:
 
             # The name of the analysis is the name of the class
             analysis_name = wordnet_id_map.get(class_index, f'{class_index:08d}')


### PR DESCRIPTION
- docs/examples/meta-analysis.py: instead of truncating and appending
  each class to the analysis hdf5-file, the file was truncated for each
  class, leaving only an analysis file with a single class instead of 10
- this was fixed by first truncating the file, and then opening the file
  with the 'a' flag