### PR TITLE
Server: Remove werkzeug log suppression hack

### DIFF
--- a/virelay/server.py
+++ b/virelay/server.py
@@ -168,7 +168,6 @@ class Server:
         # console output a lot cleaner
         if not self.is_in_debug_mode:
             logging.getLogger('werkzeug').disabled = True
-            os.environ['WERKZEUG_RUN_MAIN'] = 'true'
 
         # When the application is not in debug mode, then the browser is automatically opened upon application startup
         # (the problem is, that the Flask app run() method is blocking, so we cannot start the browser when the app is


### PR DESCRIPTION
- previously, `os.environ['WERKZEUG_RUN_MAIN'] = 'true'` was used in
  server.py to suppress the warning by tricking it to run in the
  reloader, while it was not
- remove this line to print the warning to highlight that it *is* a development server
  (users should know this) and to make the server run again
- see https://github.com/cs01/gdbgui/issues/425 for reference