### PR TITLE
Fixed PyCodeStyle

### DIFF
--- a/.pycodestyle
+++ b/.pycodestyle
@@ -9,7 +9,3 @@ max-doc-length = 150
 # statement on a previous line) must have the same indentation, this is, however, not ideal for method call chaining of fluent APIs, such as the ones
 # that are used in SQLAlchemy
 ignore = E131
-
-# Warnings W503 and W504 are mutually exclusive - they concern the position of line breaks in relation to binary operators. We choose to place them
-# before the operators as per PEP recommendation, hence we select 504 here
-select = W504

--- a/virelay/model.py
+++ b/virelay/model.py
@@ -652,7 +652,7 @@ class Analysis:
 
     def __init__(
             self,
-            category_name : str,
+            category_name: str,
             human_readable_category_name: str,
             clustering_name: str,
             clustering: NDArray[numpy.int64],
@@ -1092,7 +1092,7 @@ class LabelMap:
         """
 
     @overload
-    def get_labels(self, reference:  list[int] | tuple[int, ...] | NDArray[numpy.int64]) -> list['Label']:
+    def get_labels(self, reference: list[int] | tuple[int, ...] | NDArray[numpy.int64]) -> list['Label']:
         """Retrieves the human-readable names of the labels that match the specified reference. The reference must be a n-hot encoded vector.
 
         Args:
@@ -1275,6 +1275,7 @@ class LabelMap:
         """
 
         return self.get_label_from_word_net_id(word_net_id).name
+
 
 @dataclass
 class Label:


### PR DESCRIPTION
As it turned out, the semantics of the select option must have changed. Instead of selecting a warning or error in addition to all the ones that are selected by default, it only selects the ones that are explicitly listed. Therefore, I removed the option to select a single warning, which seems to have been removed anyway. Now, PyCodeStyle will correctly report errors. All errors reported by PyCodeStyle have been fixed.

Closes #50.