### PR TITLE
Removed the "LICENSE" file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
   - The version of the `setup-python` action was updated to the latest version v5.
   - The `jobs.docs.strategy.fail-fast` option was previously used to prevent the workflow from stopping if the documentation build failed. However, this option is only supported for matrix strategies. Since the `docs` job does not use a matrix strategy, the `jobs.docs.strategy.fail-fast` option was replaced with the `jobs.docs.continue-on-error` option.
 - Moved the ViRelAy logo from the `docs/images` directory a new top-level directory called `design`, in order to clean up the repository.
+- Removed the `LICENSE` file. Previously, there were two license files: `COPYING`, which contained the AGPL 3.0 license text, and `LICENSE`, which contained a note about where to find the license of the project and any third-party licenses. This was done, because GPL prefers the file name `COPYING`, but back then GitHub did not support that file name. Now, GitHub also supports `COPYING`. As the information about where to find the project license and the third-party licenses is also contained in the read me, the `LICENSE` file was removed.
 
 ## v0.4.0
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,0 @@
-* ViRelAy is licensed under the GNU AFFERO GENERAL PUBLIC LICENSE VERSION 3 OR
-  LATER -- see the 'COPYING' files in the root directory for details.
-* For licenses of bundled third party software packages see
-  virelay/frontend/distribution/3rdpartylicenses.txt

--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ To help speed up the merging of your pull request, please comment and document y
 
 ## License
 
-ViRelAy is licensed under the GNU AFFERO GENERAL PUBLIC LICENSE VERSION 3 OR LATER. For more information see the [copying](COPYING) and the [license](LICENSE) files. For licenses of bundled third party software packages please refer to the [3rd party license list](virelay/frontend/distribution/3rdpartylicenses.txt).
+ViRelAy is licensed under the GNU AFFERO GENERAL PUBLIC LICENSE VERSION 3 OR LATER. For more information see the [copying](COPYING). For licenses of bundled third party software packages please refer to the [3rd party license list](virelay/frontend/distribution/3rdpartylicenses.txt).


### PR DESCRIPTION
Previously, there were two license files: "COPYING", which contained the AGPL 3.0 license text, and "LICENSE", which contained a note about where to find the license of the project and any third-party licenses. This was done, because GPL prefers the file name "COPYING", but back then GitHub did not support that file name. Now, GitHub also supports "COPYING". As the information about where to find the project license and the third-party licenses is also contained in the read me, the "LICENSE" file was removed.

Closes #45.