### PR TITLE
Added more type hints to the codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@
     - The configuration Python file for building the documentation `docs/source/conf.py` was using the `pkg_resources` module, which has been deprecated and was removed in Python 3.12. It was replaced by the much simpler `Module.__file__` property.
     - In previous versions, Flask was using `application/javascript` as the MIME type for JavaScript files. This has now been changed to `text/javascript`. Also, in Python 3.12, Flask now uses `image/x-icon` instead of `image/vnd.microsoft.icon`. For this reason, the unit tests were updated.
     - The server previously also used the `pkg_resources` module to serve the static frontend files from the package directory. Since the module is now deprecated and was removed in Python 3.12, it was replaced with the `importlib.resources` module.
-- The Ubuntu and Python versions used by "Read the Docs" to build the documentation were also updated to the latest versions, i.e., Ubuntu 24.04 and Python 3.12.
+- The Sphinx build configuration and the configuration for "Read the Docs" were updated:
+  - The year in the copyright notice of the documentation is now always set to the current year.
+  - The way the GitHub URLs for the source code links are generated has been updated and now also supports type hints, which have to be handled differently from modules, classes, methods, and functions, because they are variables.
+  - The Ubuntu and Python versions used by "Read the Docs" to build the documentation were also updated to the latest versions, i.e., Ubuntu 24.04 and Python 3.12.
 - The versions of Python and the versions of the dependencies were also updated in the `tox.ini` configuration file.
 - Improved the Python Linting
   - The Flake8 linter was replaced by [PyCodeStyle](https://pycodestyle.pycqa.org/en/latest/intro.html) and [PyDocLint](https://jsh9.github.io/pydoclint/), and [MyPy](https://mypy-lang.org/) was added as a static type checker. All four checkers are now included in the `setup.py` as extra dependencies under the name `linting`, so that developers can install them if they want to use them locally, e.g., as a Visual Studio Code integration.
@@ -20,6 +23,7 @@
   - The maximum line length was increased from 120 to 150, which makes it now easier to break some longer lines
   - The Flake8 and PyLint jobs were removed from the GitHub Actions Workflow configuration file, and the new job `lint-and-type-check` was added, which runs the tox test environment "linting" to run the linters and the static type checker.
   - The documentation was updated to reflect the changes in the linting process and to explain how to run the linters and the static type checker locally.
+  - In order to improve MyPy's ability to reason about the types and therefore find bugs, many type hints were added throughout the code. Also, types were introduced to make the dictionaries that are loaded from or written to YAML/JSON files strongly typed.
   - The entire code base was linted and type-checked, and all issues found by the linters and the type checker were fixed. Thanks to the new linters and the new type checker, several obscure bugs were found that would have gone unnoticed otherwise:
     1. The automatic reload of the Flask server was not working correctly, because instead of using the property "debug", the incorrect property "auto_reload" was used.
     2. The ViRelAy modules were imported using the relative import syntax instead of the absolute import syntax, which may cause problems because sometimes it is not clear if an import is relative or not, relative imports can be ambiguous, they are brittle and may break when a module is moved, and since Python 3, implicit relative imports are not allowed anymore.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,8 @@ To help speed up the merging of your pull request, please comment and document y
 ## License
 
 ViRelAy is licensed under the GNU AFFERO GENERAL PUBLIC LICENSE VERSION 3 OR LATER. For more information see the [copying](COPYING). For licenses of bundled third party software packages please refer to the [3rd party license list](virelay/frontend/distribution/3rdpartylicenses.txt).
+
+## TODO:
+
+- [ ] Maybe document the tox configuration, because it is quite confusing for people not familiar with tox
+- [ ] Maybe move the ViRelAy module directory into a source folder and move the Docker tox files either into the source folder or the tests folder

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,18 +3,24 @@
 # pylint: disable=invalid-name
 
 import os
+import re
 import sys
 import inspect
 from types import ModuleType
-from typing import Any, Iterator, Literal
+from datetime import datetime
 from collections.abc import Sequence
 from subprocess import run, CalledProcessError
+from typing import Any, Iterator, TypeAlias, Literal
 
 from sphinx.application import Sphinx
 from pybtex.database import Entry
 from pybtex.plugin import register_plugin
 from pybtex.style.labels import BaseLabelStyle
 from pybtex.style.formatting.plain import Style as PlainStyle
+
+
+LanguageDomain: TypeAlias = Literal['py', 'c', 'cpp', 'javascript']
+"""Represents the different language domains for which the linkcode extension can generate links to the source in the repository."""
 
 
 class AuthorYearLabelStyle(BaseLabelStyle):
@@ -79,13 +85,144 @@ def get_latest_git_tag() -> str:
         return 'master'
 
 
-def linkcode_resolve(domain: Literal['py', 'c', 'cpp', 'javascript'], info: dict[str, str]) -> str | None:
+def get_object_by_name(name: str, module: ModuleType) -> ModuleType | type[Any] | None:
+    """Retrieves the object with the specified name from the specified module. The object can be a module, a class, a method, a function, or a
+    variable. If the name is not valid or the object does not exist, then None is returned.
+
+    Args:
+        name (str): The name of the object to retrieve.
+        module (ModuleType): The module from which to retrieve the object.
+
+    Returns:
+        ModuleType | type[Any] | None: Returns the object with the specified name from the specified module. If the object does not exist, then
+            None is returned.
+    """
+
+    name_components = name.split('.')
+    if not name_components:
+        return None
+
+    object_to_retrieve: ModuleType | type[Any] = module
+    for name_component in name_components:
+        try:
+            object_to_retrieve = getattr(object_to_retrieve, name_component)
+        except AttributeError:
+            return None
+
+    return object_to_retrieve
+
+
+def get_top_level_module(module_name_hierarchy: str) -> ModuleType | None:
+    """Retrieves the top-level module from the specified module name hierarchy. For example, if the module hierarchy is "a.b.c", then the module "a"
+    will be returned. If the module name hierarchy is "a", then "a" will be returned. If the module name hierarchy is not valid or the top-level
+    module of the hierarchy does not exist, then None is returned.
+
+    Args:
+        module_name_hierarchy (str): The module name hierarchy from which the top-level module is to be retrieved.
+
+    Returns:
+        ModuleType | None: Returns the top-level module from the specified module name. If the module does not exist, then None is returned.
+    """
+
+    module_hierarchy_names = module_name_hierarchy.split('.')
+    if not module_hierarchy_names:
+        return None
+
+    top_module_name = module_hierarchy_names[0]
+    top_module = sys.modules.get(top_module_name)
+    if top_module is None:
+        return None
+
+    return top_module
+
+
+def is_type_alias_for_literal(object_to_check: Any) -> bool:
+    """Checks if the specified object is a type alias for a Literal[...] type.
+
+    Args:
+        object_to_check (Any): The object to check.
+
+    Returns:
+        bool: Returns True if the specified object is a type alias for a Literal[...] type, otherwise False.
+    """
+
+    return type(object_to_check).__name__ == '_LiteralGenericAlias'
+
+
+def get_source_code_location_of_literal_type_alias(name: str, module: ModuleType) -> tuple[str | None, int | None, int | None]:
+    """Retrieves the path to the source code file that contains the type alias for the Literal[...] type, as well as the start and end line numbers of
+    the type alias declaration. If the type alias for the Literal[...] type does not exist, then None is returned for all three values.
+
+    Args:
+        name (str): The name of the type alias for the Literal[...] type.
+        module (ModuleType): The module that contains the type alias for the Literal[...] declaration.
+
+    Returns:
+        tuple[str | None, int | None, int | None]: Returns a tuple containing the path to the source code file that contains the type alias for the
+            Literal[...] type, as well as the start and end line numbers of the type alias declaration. If the type alias for the Literal[...] type
+            does not exist, then None is returned for all three values.
+    """
+
+    # Checks if the module's file path is available, if not, then there is no source file that we can check
+    if module.__file__ is None:
+        return None, None, None
+
+    # Loads the module's source code file into memory
+    with open(module.__file__, mode='r', encoding='utf-8') as module_file:
+        module_file_contents = module_file.read()
+
+    # Checks if the type alias declaration is present in the module's source code file, if not then we cannot generate a URL to the source code
+    match: re.Match[str] | None = re.search(
+        r'(type \s*)?' + name + r"\s* (: \s* TypeAlias)? \s* = \s* Literal \s* \[ \s* (\s* ['\"] [^'\"]* ['\"] ,?)* \s* \]",
+        module_file_contents,
+        re.VERBOSE
+    )
+    if not match:
+        return None, None, None
+
+    # Gets the start and the end line number of the type alias declaration
+    start_index, end_index = match.span()
+    start_line_number = module_file_contents.count('\n', 0, start_index) + 1
+    end_line_number = module_file_contents.count('\n', 0, end_index) + 1
+
+    # Returns the path to the source code file that contains the type alias declaration, and the start and end line numbers of the declaration
+    return module.__file__, start_line_number, end_line_number
+
+
+def get_source_code_location_of_object(object_to_get_location_for: ModuleType | type[Any]) -> tuple[str | None, int | None, int | None]:
+    """Retrieves the path to the source code file that contains the specified object, as well as the start and end line numbers of the object's
+    definition. The object can be a module, a class, a method, a or function. If the source code file path is not available, or the object's
+    definition cannot be found, then None is returned for all three values.
+
+    Args:
+        object_to_get_location_for (ModuleType | type[Any]): The object for which the source code location is to be retrieved.
+
+    Returns:
+        tuple[str | None, int | None, int | None]: Returns a tuple containing the path to the source code file that contains the specified object,
+            as well as the start and end line numbers of the object's definition. If the source code file path is not available, or the object's
+            definition cannot be found, then None is returned for all three values.
+    """
+
+    # Gets the absolute path to the source code file that contains the object
+    source_file_path = inspect.getsourcefile(object_to_get_location_for)
+    if source_file_path is None:
+        return None, None, None
+
+    # Retrieves the line number at which the object's definition starts and the line number where it ends
+    try:
+        source, start_line_number = inspect.getsourcelines(object_to_get_location_for)
+        end_line_number = start_line_number + len(source) - 1
+        return source_file_path, start_line_number, end_line_number
+    except OSError:
+        return None, None, None
+
+
+def linkcode_resolve(domain: LanguageDomain, info: dict[str, str]) -> str | None:
     """Determines the URL to the source code corresponding to the object in the specified domain with the provided information. This function was
     adapted from https://gist.github.com/nlgranger/55ff2e7ff10c280731348a16d569cb73.
 
     Args:
-        domain (Literal['py', 'c', 'cpp', 'javascript']): Specified the language domain the object is in. Can be one of "py", "c", "cpp", or
-            "javascript".
+        domain (LanguageDomain): Specified the language domain the object is in. Can be one of "py", "c", "cpp", or "javascript".
         info (dict[str, str]): A dictionary, which contains further information about the object for which the URL is to be retrieved. Depending on
             the domain, the following keys are guaranteed to be present:
              - domain is "py":
@@ -113,51 +250,43 @@ def linkcode_resolve(domain: Literal['py', 'c', 'cpp', 'javascript'], info: dict
         return None
 
     # Gets the object for which the source code URL is to be retrieved
-    name_components = info['fullname'].split('.')
-    if not name_components:
-        return None
-    object_to_get_url_for: ModuleType | type[Any] = module
-    for name_component in name_components:
-        try:
-            object_to_get_url_for = getattr(object_to_get_url_for, name_component)
-        except AttributeError:
-            return None
-
-    # Gets the absolute path to the source code file that contains the object
-    object_file_path: str | None = inspect.getsourcefile(object_to_get_url_for)
-    if object_file_path is None:
+    object_to_get_url_for: ModuleType | type[Any] | None = get_object_by_name(info['fullname'], module)
+    if object_to_get_url_for is None:
         return None
 
-    # The path to the source code file is absolute, so it must be converted to a path relative to the top module's path (this should always be the
-    # virelay module; example: source code file path: /a/b/c/virelay/d/e.py, top module path: /a/b/c/virelay, and what we need is virelay/d/e.py); the
-    # path returned by the __file__ attribute of the top module points to the module's __init__.py file, e.g., /a/b/c/virelay/__init__.py, so we need
-    # to remove the __init__.py part to get the top module's path; then, we also need to remove the directory that the top module is contained in,
-    # e.g., /a/b/c; this is needed because the function that turns the absolute into a relative path removes the common prefix of the two paths, which
-    # would mean that we would end up with d/e.py instead of virelay/d/e.py
-    module_hierarchy = info['module'].split('.')
-    if not module_hierarchy:
+    # Unfortunately, type aliases for Literal[...]'s (such as LanguageDomain) are not supported by the getsourcefile function, because they are not
+    # real types, but objects of the typing._LiteralGenericAlias class, and getsourcefile only supports modules, classes, methods, and functions;
+    # therefore, the only option we have is that we find the declaration of the type alias in the file of the module it is located in and then use
+    # the line number of the type alias declaration to generate the URL to the source code file on GitHub; otherwise, we can use the getsourcefile and
+    # getsourcelines functions to generate the URL to the source code file on GitHub
+    if is_type_alias_for_literal(object_to_get_url_for):
+        object_file_path, start_line_number, end_line_number = get_source_code_location_of_literal_type_alias(info['fullname'], module)
+    else:
+        object_file_path, start_line_number, end_line_number = get_source_code_location_of_object(object_to_get_url_for)
+
+    # If the source code file path, the start line number, or the end line number is not available, then we cannot generate a URL to the source code
+    if object_file_path is None or start_line_number is None or end_line_number is None:
         return None
-    top_module_name = module_hierarchy[0]
-    top_module = sys.modules.get(top_module_name)
+
+    # The path to the source code file is absolute, so it must be converted to a path relative to the top module's path (example: source code file
+    # path: /a/b/c/virelay/d/e.py, top module path: /a/b/c/virelay, and what we need is virelay/d/e.py); the path returned by the __file__ attribute
+    # of the top module points to the module's __init__.py file, e.g., /a/b/c/virelay/__init__.py, so we need to remove the __init__.py part to get
+    # the top module's path; then, we also need to remove the directory that the top module is contained in, e.g., /a/b/c; this is needed because the
+    # function that turns the absolute into a relative path removes the common prefix of the two paths, which would mean that we would end up with
+    # d/e.py instead of virelay/d/e.py
+    top_module = get_top_level_module(info['module'])
     if top_module is None or top_module.__file__ is None:
         return None
     top_module_path = os.path.abspath(os.path.join(os.path.dirname(top_module.__file__), '..'))
     object_file_path = os.path.relpath(object_file_path, top_module_path)
 
-    # Retrieves the line number at which the object's definition starts and the line number where it ends
-    try:
-        source, line_number = inspect.getsourcelines(object_to_get_url_for)
-        line_start, line_stop = line_number, line_number + len(source) - 1
-    except OSError:
-        return None
-
     # Composes the URL to the source code file on GitHub and returns it
-    return f'https://github.com/virelay/virelay/blob/{LATEST_GIT_TAG}/{object_file_path}#L{line_start}-L{line_stop}'
+    return f'https://github.com/virelay/virelay/blob/{LATEST_GIT_TAG}/{object_file_path}#L{start_line_number}-L{end_line_number}'
 
 
 # Sets the basic project information
 project = 'ViRelAy'
-project_copyright = '2024, ViRelAy'
+project_copyright = f'{datetime.now().year}, ViRelAy'
 author = 'ViRelAy Contributors'
 
 # Specifies the Sphinx extensions that are used by this documentation

--- a/docs/source/contributors-guide/project-file-format.rst
+++ b/docs/source/contributors-guide/project-file-format.rst
@@ -58,9 +58,12 @@ The project YAML file consists of a project name, a model name, a reference to t
 
 - ``project`` → ``dataset`` → ``down_sampling_method``: The down-sampling methods determine how the images are scaled down when they are bigger than the specified input size. Possible values are:
 
-  - ``none``: No up-sampling is performed.
+  - ``none``: No down-sampling is performed.
   - ``center_crop``: A central part of the image with the desired size will be cut out.
   - ``resize``: The image will be scaled to the desired size.
+
+- ``project`` → ``dataset`` → ``label_index_regex``: A regular expression, which is used to parse the path of a sample for the label index. The sample index must be captured in the first group. Can be ``None``, but if the dataset type is ``image_directory``, then either ``label_index_regex`` or ``label_word_net_id_regex`` must be specified.
+- ``project`` → ``dataset`` → ``label_word_net_id_regex``: A regular expression, which is used to parse the path of a sample for the WordNet ID of the label. The WordNet ID must be captured in the first group. Can be ``None``, but if the dataset type is ``image_directory``, then either ``label_index_regex`` or ``label_word_net_id_regex`` must be specified.
 
 - ``project`` → ``attributions``: The attributions that were computed for the entire dataset using the classifier model.
 - ``project`` → ``attributions`` → ``attribution_method``: The name of the method that was used to compute the attributions, e.g., the name of an LRP variant.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(
         'matplotlib>=3.9.2,<4.0.0',
         'numpy>=2.1.1,<3.0.0',
         'pillow>=10.4.0,<11.0.0',
-        'pyyaml>=6.0.2,<7.0.0'
+        'pyyaml>=6.0.2,<7.0.0',
+        'typing-extensions>=4.12.2,<5.0.0'
     ],
     setup_requires=[
         'setuptools_scm>=8.1.0,<9.0.0'

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -7,6 +7,7 @@ import numpy
 import pytest
 
 from virelay.model import (
+    DownSamplingMethod,
     Project,
     AttributionDatabase,
     Attribution,
@@ -18,6 +19,7 @@ from virelay.model import (
     Sample,
     LabelMap,
     Label,
+    UpSamplingMethod,
     Workspace
 )
 
@@ -115,11 +117,8 @@ class TestProject:
             project_file_without_dataset_path (str): The path to the project file that is used for the tests.
         """
 
-        project = Project(project_file_without_dataset_path)
-        assert project.dataset is None
-
         with pytest.raises(ValueError):
-            project.get_sample(0)
+            Project(project_file_without_dataset_path)
 
     @staticmethod
     def test_project_creation_with_broken_project_file(broken_project_file_path: str) -> None:
@@ -1168,7 +1167,7 @@ class TestImageDirectoryDataset:
                 label_word_net_id_regex=None,
                 input_width=64,
                 input_height=64,
-                down_sampling_method='unsupported',
+                down_sampling_method='unsupported',  # type: ignore
                 up_sampling_method='none',
                 label_map=label_map
             )
@@ -1429,7 +1428,9 @@ class TestImageDirectoryDataset:
         assert sample.data.shape[1] == 64
 
         # Checks all down-sampling methods
-        for down_sampling_method in ['center_crop', 'resize']:
+        down_sampling_method: DownSamplingMethod
+        down_sampling_methods: list[DownSamplingMethod] = ['center_crop', 'resize']
+        for down_sampling_method in down_sampling_methods:
             image_directory_dataset = ImageDirectoryDataset(
                 name="Test Dataset",
                 path=image_directory_dataset_with_label_indices_path,
@@ -1474,7 +1475,8 @@ class TestImageDirectoryDataset:
         assert sample.data.shape[1] == 64
 
         # Checks all down-sampling methods
-        up_sampling_methods = ['fill_zeros', 'fill_ones', 'edge_repeat', 'mirror_edge', 'wrap_around', 'resize']
+        up_sampling_method: UpSamplingMethod
+        up_sampling_methods: list[UpSamplingMethod] = ['fill_zeros', 'fill_ones', 'edge_repeat', 'mirror_edge', 'wrap_around', 'resize']
         for up_sampling_method in up_sampling_methods:
             image_directory_dataset = ImageDirectoryDataset(
                 name="Test Dataset",
@@ -1484,7 +1486,7 @@ class TestImageDirectoryDataset:
                 input_width=128,
                 input_height=128,
                 down_sampling_method='none',
-                up_sampling_method=up_sampling_method,  # type: ignore
+                up_sampling_method=up_sampling_method,
                 label_map=label_map
             )
             sample = image_directory_dataset.get_sample(0)

--- a/virelay/application.py
+++ b/virelay/application.py
@@ -49,7 +49,7 @@ class Application:
         """Initializes a new Application instance."""
 
         # Initializes the command line argument parser
-        self.argument_parser = argparse.ArgumentParser(
+        self.argument_parser: argparse.ArgumentParser = argparse.ArgumentParser(
             prog="virelay",
             description="The visualization tool ViRelAy."
         )
@@ -81,16 +81,15 @@ class Application:
             dest='debug_mode',
             action='store_true',
             help='''
-                Determines whether the application is run in debug mode. When the application is in debug mode, all
-                Flask and Werkzeug logs are printed to stdout, Flask debugging is activated (Flask will print out the
-                debugger PIN for attaching the debugger), and automatic reloading (when files change) is activated.
-                Furthermore, the frontend of the application will not be served by Flask and instead has to be served
-                externally (e.g. via ng serve).
+                Determines whether the application is run in debug mode. When the application is in debug mode, all Flask and Werkzeug logs are
+                printed to stdout, Flask debugging is activated (Flask will print out the debugger PIN for attaching the debugger), and automatic
+                reloading (when files change) is activated. Furthermore, the frontend of the application will not be served by Flask and instead has
+                to be served externally (e.g. via ng serve).
             '''
         )
 
         # Initializes the workspace, which will contain all the loaded projects
-        self.workspace = Workspace()
+        self.workspace: Workspace = Workspace()
 
     def run(self) -> None:
         """Runs the application."""
@@ -102,9 +101,9 @@ class Application:
         for project_path in arguments.project:
             self.workspace.add_project(project_path)
 
-        # Registers the cleanup method, which will be called when the application is quit (the Flask server is long
-        # running and will only exit when the user sends a signal, e.g. via Ctrl+C, to stop the process, atexit
-        # registers a callback, which is executed, when the Python interpreter is shut down)
+        # Registers the cleanup method, which will be called when the application is quit (the Flask server is long running and will only exit when
+        # the user sends a signal, e.g. via Ctrl+C, to stop the process, atexit registers a callback, which is executed, when the Python interpreter
+        # is shut down)
         atexit.register(self.shutdown)
 
         # Creates the Flask server, which serves the frontend website as well as the RESTful API


### PR DESCRIPTION
In order to improve MyPy's ability to reason about the types and therefore find bugs, many type hints were added throughout the code. Types were introduced to make the dictionaries that are loaded from or written to YAML/JSON files strongly typed. Also, types were added for strings that have a specific set of possible values.

For the literal types for strings with a specific set of possible values, type aliases were created, so that the same type can be reused in multiple places. This makes it easier to change the set of possible values in the future, as the change only needs to be made in one place. This, however, also made it necessary to change the code for generating the GitHub URLs for the source code links, because literal types are no real types, but instances of a class. The regular code for finding the file name and the line numbers of the source code corresponding to modules, classes, methods and functions cannot be used. Instead, an alternative approach was implemented that assumes that the type alias for the literal type is located in the same file as the module it belongs to. This is a reasonable assumption and works for all current uses of literal types. To find the line number of the type alias, the source code of the module file is loaded and parsed using a regular expression that matches the type alias definition. This approach is not as robust as using the "inspect" module, but it works well in practice.

Finally, the year of the copyright notice in the Sphinx build configuration is now always set to the current year, which means we do not have to remember to update it every year.

Closes #53.