### PR TITLE
Separate Jobs for the Linters & Type Checker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,9 @@ on:
       - master
       - develop
 
-# This workflow contains four jobs: test, which runs the unit tests, lint, which runs the linters and the static type checker, spell-check, which runs
-# the spell checker, and docs, which builds the documentation
+# This workflow contains seven jobs: "unit-tests", which runs the unit tests, "pylint", which runs the PyLint linter, "pycodestyle", which runs the
+# linter PyCodeStyle, "pydoclint", which runs the docstring linter, "mypy", which runs the MyPy static type checker, "spell-check", which runs the
+# spell checker, and "build-documentation", which builds the documentation
 jobs:
 
   # The first job runs the unit tests on Python 3.10, 3.11, and 3.12
@@ -56,15 +57,15 @@ jobs:
       - name: Run Unit Tests
         run: tox --skip-pkg-install -e ${{ matrix.tox-environment }}
 
-  # The second job runs the linters (PyLint, PyCodeStyle, and PyDocLint) and the static type checker (MyPy)
-  lint-and-type-check:
+  # The second job runs the PyLint linter
+  pylint:
 
     # The job will run on the latest version of Ubuntu
-    name: Lint & Type-Check ViRelAy Backend
+    name: Lint ViRelAy Backend Using PyLint
     runs-on: ubuntu-latest
 
     # The job contains several steps: 1) checking out the repository, 2) installing the base Python version, which is the version of Python used to
-    # run tox itself, 3) installing tox, 4) setting up the linting and type-checking environment, and 5) running the linters and the type-checker
+    # run tox itself, 3) installing tox, 4) setting up the PyLint environment, and 5) running the PyLint linter
     steps:
       - uses: actions/checkout@v4
         with:
@@ -75,12 +76,84 @@ jobs:
           python-version: "3.12"
       - name: Install tox
         run: python -m pip install tox
-      - name: Setup Linting & Type-Checking Environment
-        run: tox -vv --notest -e linting
-      - name: Run Linters & Type-Checker
-        run: tox --skip-pkg-install -e linting
+      - name: Setup PyLint Environment
+        run: tox -vv --notest -e pylint
+      - name: Run PyLint Linter
+        run: tox --skip-pkg-install -e pylint
 
-  # The third job runs the spell checker CSpell to spell-check all files in the repository
+  # The third job runs the PyCodeStyle linter
+  pycodestyle:
+
+    # The job will run on the latest version of Ubuntu
+    name: Lint ViRelAy Backend Using PyCodeStyle
+    runs-on: ubuntu-latest
+
+    # The job contains several steps: 1) checking out the repository, 2) installing the base Python version, which is the version of Python used to
+    # run tox itself, 3) installing tox, 4) setting up the PyCodeStyle environment, and 5) running the PyCodeStyle linter
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Base Python for tox
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Setup PyCodeStyle Environment
+        run: tox -vv --notest -e pycodestyle
+      - name: Run PyCodeStyle Linter
+        run: tox --skip-pkg-install -e pycodestyle
+
+  # The fourth job runs the PyDocLint docstring linter
+  pydoclint:
+
+    # The job will run on the latest version of Ubuntu
+    name: Lint ViRelAy Backend Docstrings Using PyDocLint
+    runs-on: ubuntu-latest
+
+    # The job contains several steps: 1) checking out the repository, 2) installing the base Python version, which is the version of Python used to
+    # run tox itself, 3) installing tox, 4) setting up the PyDocLint environment, and 5) running the PyDocLint docstring linter
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Base Python for tox
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Setup PyDocLint Environment
+        run: tox -vv --notest -e pydoclint
+      - name: Run PyDocLint Linter
+        run: tox --skip-pkg-install -e pydoclint
+
+  # The fifth job runs the MyPy static type checker
+  mypy:
+
+    # The job will run on the latest version of Ubuntu
+    name: Static Type-Check ViRelAy Backend Using MyPy
+    runs-on: ubuntu-latest
+
+    # The job contains several steps: 1) checking out the repository, 2) installing the base Python version, which is the version of Python used to
+    # run tox itself, 3) installing tox, 4) setting up the MyPy environment, and 5) running the MyPy static type checker
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Base Python for tox
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Setup MyPy Environment
+        run: tox -vv --notest -e mypy
+      - name: Run MyPy Linter
+        run: tox --skip-pkg-install -e mypy
+
+  # The sixth job runs the spell checker CSpell to spell-check all files in the repository
   spell-check:
 
     # The job will run on the latest version of Ubuntu; usually, when a job fails, the entire workflow will fail, but in this case, we do not want the
@@ -104,7 +177,7 @@ jobs:
       - name: Run Spell-Check
         run: npx cspell lint . --config tests/config/.cspell.json
 
-  # The fourth job builds the documentation using Sphinx
+  # The seventh job builds the documentation using Sphinx
   build-documentation:
 
     # The job will run on the latest version of Ubuntu; usually, when a job fails, the entire workflow will fail, but in this case, we do not want the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@
 - Improved the Python Linting
   - The Flake8 linter was replaced by [PyCodeStyle](https://pycodestyle.pycqa.org/en/latest/intro.html) and [PyDocLint](https://jsh9.github.io/pydoclint/), and [MyPy](https://mypy-lang.org/) was added as a static type checker. All four checkers are now included in the `setup.py` as extra dependencies under the name `linting`, so that developers can install them if they want to use them locally, e.g., as a Visual Studio Code integration.
   - New configurations for PyCodeStyle, PyDocLint, and MyPy were added and the configuration file for PyLint was updated to match the latest version of PyLint.
-  - The PyLint and Flake8 test environments were removed from the `tox.ini` file and the new test environment `linting` was added, which runs all linters and the static type checker.
+  - The `flake8` test environment was removed from the `tox.ini` file and the new test environments `pycodestyle`, `pydoclint` and `mypy` were added, which run the linters and the static type checker.
   - The maximum line length was increased from 120 to 150, which makes it now easier to break some longer lines
-  - The Flake8 and PyLint jobs were removed from the GitHub Actions Workflow configuration file, and the new job `lint-and-type-check` was added, which runs the tox test environment "linting" to run the linters and the static type checker.
+  - The Flake8 job was removed from the GitHub Actions Workflow configuration file, and the new jobs `pycodestyle`, `pydoclint` and `mypy` were added, which run the tox environments for the respective linter and the static type checker.
   - The documentation was updated to reflect the changes in the linting process and to explain how to run the linters and the static type checker locally.
   - In order to improve MyPy's ability to reason about the types and therefore find bugs, many type hints were added throughout the code. Also, types were introduced to make the dictionaries that are loaded from or written to YAML/JSON files strongly typed.
   - The entire code base was linted and type-checked, and all issues found by the linters and the type checker were fixed. Thanks to the new linters and the new type checker, several obscure bugs were found that would have gone unnoticed otherwise:

--- a/README.md
+++ b/README.md
@@ -73,8 +73,3 @@ To help speed up the merging of your pull request, please comment and document y
 ## License
 
 ViRelAy is licensed under the GNU AFFERO GENERAL PUBLIC LICENSE VERSION 3 OR LATER. For more information see the [copying](COPYING). For licenses of bundled third party software packages please refer to the [3rd party license list](virelay/frontend/distribution/3rdpartylicenses.txt).
-
-## TODO:
-
-- [ ] Maybe document the tox configuration, because it is quite confusing for people not familiar with tox
-- [ ] Maybe move the ViRelAy module directory into a source folder and move the Docker tox files either into the source folder or the tests folder

--- a/docs/source/contributors-guide/backend-rest-api.rst
+++ b/docs/source/contributors-guide/backend-rest-api.rst
@@ -76,11 +76,11 @@ Unit Testing
 
 The backend REST API has a unit test suite which strives to always reach 100% code coverage. The tests are not situated in the ViRelAy module, but in a separate tests directory: :repo:`tests/unit_tests`. The ``conftest`` module contains common fixtures that are used by the tests. Each ViRelAy module has an accompanying test module, which contains the tests for it (e.g., the ``image_processing`` ViRelAy module has a ``test_image_processing`` test module). The tests are written using the PyTest framework. The tests for ViRelAy classes are also contained in classes (e.g., the ``Project`` class in the ``model`` ViRelAy module has a matching ``TestProject`` test class), while the tests for functions are also just plain functions. The convention is to name a test function or method with the prefix ``test_`` followed by the name of the function or method being tested, followed by a description of the test. For example, the function that tests whether heatmaps can be rendered with the blue-white-red color map is called ``test_render_heatmap_blue_white_red``. When contributing to the project, you should always ensure that all tests run successfully and that all altered or added functionality is being properly tested.
 
-The easiest way to run the unit tests is through tox. To run all tox environments, i.e., ``py310``, ``py311`` and ``py312`` for the unit tests using Python 3.10, 3.11 and 3.12, ``coverage`` for computing the test coverage, ``linting`` for running the linters and the static type checker, and ``docs`` for building the documentation, you can just invoke the ``tox`` command in your terminal without any arguments. To run specific environments, you can use the ``-e`` parameter. For example, to run the unit tests for Python 3.10, and the linters and static type checker you can use the following command:
+The easiest way to run the unit tests is through tox. To run all tox environments, i.e., ``py310``, ``py311`` and ``py312`` for the unit tests using Python 3.10, 3.11 and 3.12, ``coverage`` for combining the test coverage data and producing a report, ``pylint``, ``pycodestyle`` and ``pydoclint`` for running the linters, ``mypy`` for running the static type checker, and ``docs`` for building the documentation, you can just invoke the ``tox`` command in your terminal without any arguments. To run specific environments, you can use the ``-e`` parameter. For example, to run the unit tests for Python 3.10, and the PyLint linter you can use the following command:
 
 .. code-block:: console
 
-    tox -e py310,linting
+    tox -e py310,pylint
 
 Using tox, the unit tests can be run with all supported Python versions. For this to work, all supported Python versions, i.e., Python 3.10, 3.11 and 3.12, must be installed on your system. If you cannot or do not want to install all supported Python versions on your system, you can also run tox in Docker. For this to work, you need to have Docker installed on your system, which can be achieved by following the `official installation instructions <https://docs.docker.com/engine/install/>`_. Then you can run tox inside of Docker using our bundled convenience script:
 
@@ -92,7 +92,7 @@ The script will automatically build a Docker image with all necessary dependenci
 
 .. code-block:: console
 
-    ./tests/docker-tox/docker-tox -e py310,linting
+    ./tests/docker-tox/docker-tox -e py310,pylint
 
 The tests can also be manually executed using the ``pytest`` command line interface, like so:
 
@@ -121,17 +121,17 @@ The code style of the backend REST API is checked using `PyLint <https://www.pyl
 
 The configuration for PyLint can be found in the :repo:`tests/config/.pylintrc` file, the PyCodeStyle configuration can be found in the :repo:`tests/config/.pycodestyle` file, PyDocLint's configuration can be found in the :repo:`tests/config/.pydoclint.toml` file, and the configuration for MyPy can be found in the :repo:`tests/config/.mypy.ini` file.
 
-Again, the easiest way to execute the linting is through tox:
+Again, the easiest way to run all linters and the static type checker is through tox:
 
 .. code-block:: console
 
-    tox -e linting
+    tox -e pylint,pycodestyle,pydoclint,mypy
 
 Of course, the same can be achieved using tox in Docker:
 
 .. code-block:: console
 
-    ./tests/docker-tox/docker-tox -e linting
+    ./tests/docker-tox/docker-tox -e pylint,pycodestyle,pydoclint,mypy
 
 However, the linters and the type checker can also be directly run, if you have installed them in your virtual environment (``.venv/bin/pip install --editable .[linting]``):
 

--- a/tests/config/.cspell.json
+++ b/tests/config/.cspell.json
@@ -117,6 +117,7 @@
         "Dockerized",
         "docstrings",
         "doctree",
+        "docz",
         "dtick",
         "dtype",
         "dvipng",

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,20 @@
-[tox]
-skip_missing_interpreters = true
-envlist = py310,py311,py312,linting,docs
 
+# Core tox configuration
+[tox]
+
+# A list of environments that will be run by default when running tox without specifying any environment
+env_list = py310,py311,py312,coverage,pylint,pycodestyle,pydoclint,mypy,docs
+
+# Even if some of the environments fail due to missing interpreters, tox will return success (this is helpful when running tox locally without having
+# all supported Python versions installed)
+skip_missing_interpreters = true
+
+# Base configuration for test environments that tox will fallback to for missing values; this avoids having to repeat the same configuration for the
+# unit test environments py310, py311, and py312 over and over again; it runs the unit tests for the backend REST API with the corresponding Python
+# version
 [testenv]
-deps =
-    pytest>=8.3.3,<9.0.0
-    pytest-cov>=5.0.0,<6.0.0
-setenv =
+extras = tests
+set_env =
     COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
 commands =
     pytest \
@@ -15,19 +23,19 @@ commands =
         --cov-append \
         {posargs:.}
 
+# A test environment that combines the coverage data from all runs of the unit tests with the different Python versions and generates a single report
 [testenv:coverage]
-deps =
-    coverage>=7.6.1,<8.0.0
-setenv =
+extras = tests
+set_env =
     COVERAGE_FILE = {toxworkdir}/.coverage
-skip_install = true
 commands =
     coverage combine
     coverage report -m
 depends = py310,py311,py312
 
+# A test environment that will build the documentation using Sphinx
 [testenv:docs]
-basepython = python3.12
+base_python = python3.12
 extras = docs
 commands =
     sphinx-build \
@@ -40,33 +48,109 @@ commands =
         "{toxinidir}/docs/build" \
         {posargs}
 
-[testenv:linting]
-basepython = python3.12
+# A test environment that will run the PyLint linter on the REST API backend, the unit tests, the setup script, and the Sphinx configuration file
+[testenv:pylint]
+base_python = python3.12
 extras =
     docs
     tests
     linting
-changedir = {toxinidir}
+change_dir = {toxinidir}
 commands =
-    pylint --rcfile=tests/config/.pylintrc --output-format=parseable virelay tests/unit_tests setup.py docs/source/conf.py
-    pycodestyle --config=tests/config/.pycodestyle virelay tests/unit_tests setup.py docs/source/conf.py
-    pydoclint --config=tests/config/.pydoclint.toml virelay tests/unit_tests setup.py docs/source/conf.py
-    mypy --config-file=tests/config/.mypy.ini virelay tests/unit_tests setup.py docs/source/conf.py
+    pylint \
+        --rcfile=tests/config/.pylintrc \
+        --output-format=parseable \
+        virelay \
+        tests/unit_tests \
+        setup.py \
+        docs/source/conf.py
 
+# A test environment that will run the PyCodeStyle linter on the REST API backend, the unit tests, the setup script, and the Sphinx configuration file
+[testenv:pycodestyle]
+base_python = python3.12
+extras =
+    docs
+    tests
+    linting
+change_dir = {toxinidir}
+commands =
+    pycodestyle \
+        --config=tests/config/.pycodestyle \
+        virelay \
+        tests/unit_tests \
+        setup.py \
+        docs/source/conf.py
+
+# A test environment that will run the PyDocLint docstring linter on the REST API backend, the unit tests, the setup script, and the Sphinx
+# configuration file
+[testenv:pydoclint]
+base_python = python3.12
+extras =
+    docs
+    tests
+    linting
+change_dir = {toxinidir}
+commands =
+    pydoclint \
+        --config=tests/config/.pydoclint.toml \
+        virelay \
+        tests/unit_tests \
+        setup.py \
+        docs/source/conf.py
+
+# A test environment that will run the MyPy static type checker on the REST API backend, the unit tests, the setup script, and the Sphinx
+# configuration file
+[testenv:mypy]
+base_python = python3.12
+extras =
+    docs
+    tests
+    linting
+change_dir = {toxinidir}
+commands =
+    mypy \
+        --config-file=tests/config/.mypy.ini \
+        virelay \
+        tests/unit_tests \
+        setup.py \
+        docs/source/conf.py
+
+# The configuration for the PyTest test runner
 [pytest]
 testpaths = tests
 addopts = -ra -l
 filterwarnings = error
 
+# The general configuration for the PyTest coverage plugin
 [coverage:run]
-parallel = true
+
+# Specifies that branch coverage should be measured
 branch = true
+
+# Causes the PyTest coverage plugin to append the machine name, process ID, and a random number to the data file name to simplify collecting data from
+# many processes; this is done because we are running the unit tests using multiple Python versions
+parallel = true
+
+# The __main__.py and application.py files cannot be tested, since they start the REST API server, therefore, they are omitted from the coverage
+# measurement and reporting
 omit=*/virelay/__main__.py,*/virelay/application.py
 
+# The configuration for the PyTest coverage plugin when generating the coverage report
 [coverage:report]
+
+# Specifies that files that have 100% coverage should be omitted from the report, so that we can focus on the files that need more testing
 skip_covered = true
+
+# Specifies that the report should include a list of the lines that were not covered by the unit tests
 show_missing = true
+
+# A list of regular expressions that will be used to exclude certain lines from the coverage measurement; here, the run method of the Server class is
+# excluded, since it starts the REST API server and cannot be tested
 exclude_lines = def run
 
+# Since the coverage data can be collected from multiple different installations of ViRelAy, the Coverage tool needs to know which files are
+# equivalent; this configuration section contains named lists (in our case only a single list called "source"), where two file paths are considered
+# equivalent and combined when running the "coverage combine" command when they are in the same list; here we specify that the files in directories
+# called virelay, /.tox/*/lib/python*/site-packages, and */virelay are equivalent
 [coverage:paths]
 source = virelay,*/.tox/*/lib/python*/site-packages/virelay,*/virelay


### PR DESCRIPTION
The GitHub Actions Workflow job for the linters and the static type checker was split up into four separate jobs, one for each linter or static type checker. Since the jobs invoke corresponding tox environments, the tox environment for the linters and the static type checker was also split up into separate environments for the linters and static type checker. The documentation was updated to reflect the changes. Also, some comments were added to the tox file to make the different sections and settings more clear.

Closes #52