### PR TITLE
Now, HTTP 404 is returned for non-existent files

### DIFF
--- a/source/backend/virelay/server.py
+++ b/source/backend/virelay/server.py
@@ -133,6 +133,8 @@ class Server:
                 def view_function() -> flask.Response:
                     with as_file(resources_path / relative_file_path) as file_path:
                         file_path = file_path.resolve()
+                        if not file_path.is_file():
+                            flask.abort(404)
                         return flask.send_file(cast(BinaryIO, file_path.open('rb')), download_name=file_path.name)
                 return view_function
 
@@ -140,6 +142,8 @@ class Server:
                 def view_function(file_name: str) -> flask.Response:
                     with as_file(resources_path / file_path_template.format(file_name)) as file_path:
                         file_path = file_path.resolve()
+                        if not file_path.is_file():
+                            flask.abort(404)
                         return flask.send_file(cast(BinaryIO, file_path.open('rb')), download_name=file_path.name)
                 return view_function
 

--- a/tests/config/.cspell.json
+++ b/tests/config/.cspell.json
@@ -195,6 +195,7 @@
         "pylintrc",
         "pytest",
         "pytyped",
+        "qwen",
         "Raycaster",
         "rcfile",
         "rdiv",


### PR DESCRIPTION
When serving the frontend files, the backend now checks if the file exists before sending it. If the file does not exist, an HTTP 404 Not Found error is returned. Previously, the backend would raise a FileNotFoundError and return an HTTP 500 Internal Server Error.

Closes issue #17.