### PR TITLE
Made the selected attributions pane responsive

### DIFF
--- a/source/frontend/components/embedding-visualizer/embedding-visualizer.component.scss
+++ b/source/frontend/components/embedding-visualizer/embedding-visualizer.component.scss
@@ -1,7 +1,7 @@
 
 // The :host pseudo selector references the component element itself; this rules causes the embedding visualizer to take up all space available to it;
-// this is done by making embedding visualizer a block element, which is required for the width and height properties to work; then the width and
-// height properties are set to 100% of its parent element
+// this is done by making it a block element, which is required for the width and height properties to work; then the width and height properties are
+// set to 100% of its parent element
 :host {
     display: block;
     width: 100%;

--- a/source/frontend/components/embedding-visualizer/embedding-visualizer.component.ts
+++ b/source/frontend/components/embedding-visualizer/embedding-visualizer.component.ts
@@ -723,8 +723,8 @@ export class EmbeddingVisualizerComponent implements AfterViewInit, OnDestroy {
 
         // Adds a camera controller for zooming and panning
         this.cameraController = new OrbitControls(this.camera, renderTargetNativeElement);
-        this.cameraController.minZoom = 0.5;
-        this.cameraController.maxZoom = 5.0;
+        this.cameraController.minZoom = 0.1;
+        this.cameraController.maxZoom = 10.0;
         this.cameraController.screenSpacePanning = true;
         this.cameraController.enableRotate = false;
 

--- a/source/frontend/pages/projects/project-page.component.html
+++ b/source/frontend/pages/projects/project-page.component.html
@@ -175,7 +175,7 @@
         </button>
     </aside>
 
-    <section id="embedding-plot">
+    <section id="embedding-visualizer">
         <virelay-embedding-visualizer
             *ngIf="analysis"
             [(ngModel)]="selectedEmbeddingVectors"

--- a/source/frontend/pages/projects/project-page.component.scss
+++ b/source/frontend/pages/projects/project-page.component.scss
@@ -8,12 +8,23 @@
 
 #panels-container {
     display: grid;
-    grid-template:
-        "options-pane options-pane" 85px
-        "embedding-plot cluster-pane" 1fr
-        "selected-attributions-pane selected-attributions-pane" 250px
-        "status-bar status-bar" 35px
-        / 1fr 250px;
+
+    --selected-attributions-pane-height: 250px;
+
+    grid-template-areas:
+        "options-pane               options-pane"
+        "embedding-visualizer       cluster-pane"
+        "selected-attributions-pane selected-attributions-pane"
+        "status-bar                 status-bar";
+    grid-template-rows: 85px 1fr var(--selected-attributions-pane-height) 35px;
+    grid-template-columns: 1fr 250px;
+
+    @media (max-height: 1080px) {
+        --selected-attributions-pane-height: 200px;
+    }
+    @media (max-height: 720px) {
+        --selected-attributions-pane-height: 150px;
+    }
 
     #options-pane {
         display: flex;
@@ -60,7 +71,7 @@
         flex-direction: column;
         grid-area: cluster-pane;
         align-items: center;
-        height: calc(100vh - 430px);
+        height: calc(100vh - 180px - var(--selected-attributions-pane-height));
         overflow: hidden auto;
         scrollbar-color: var(--virelay-scrollbar-thumb-color) var(--virelay-scrollbar-track-color);
         scrollbar-width: thin;
@@ -73,10 +84,10 @@
         }
     }
 
-    #embedding-plot {
-        grid-area: embedding-plot;
+    #embedding-visualizer {
+        grid-area: embedding-visualizer;
         width: calc(100vw - 250px);
-        height: calc(100vh - 430px);
+        height: calc(100vh - 180px - var(--selected-attributions-pane-height));
 
         #attribution-hover-preview {
             position: absolute;
@@ -127,18 +138,18 @@
         #selected-attribution-list {
             display: flex;
             align-items: center;
-            height: 226px;
+            height: calc(var(--selected-attributions-pane-height) - 2 * 12px);
             margin: 12px;
 
             .selected-attribution {
-                min-width: 180px;
-                max-width: 180px;
-                min-height: 210px;
-                max-height: 210px;
+                min-width: calc(var(--selected-attributions-pane-height) - 70px);
+                max-width: calc(var(--selected-attributions-pane-height) - 70px);;
+                min-height: calc(var(--selected-attributions-pane-height) - 40px);;
+                max-height: calc(var(--selected-attributions-pane-height) - 40px);;
 
                 img {
-                    width: 180px;
-                    height: 180px;
+                    width: calc(var(--selected-attributions-pane-height) - 70px);;
+                    height: calc(var(--selected-attributions-pane-height) - 70px);;
                 }
 
                 margin-left: 12px;


### PR DESCRIPTION
Added two breakpoints at 1080px and 720px window height, which adapt the height of the selected attributions pane (from 250px to 200px and 150px respectively). This prevents the selected attributions pane from taking up too much space when the browser window is small.

Also, increased the maximum zoom level to 10 and decreased the minimum zoom level to 0.1. When the embedding viewer is too small, then the new minimum zoom level allows users to fit more embedding vectors into the viewport, and the new maximum zoom level allows users to zoom in deeper when the window is large.

Closes issue #16.