### PR TITLE
Fixed the Sample and Heatmap Alternative Text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - The user can, however, override this option and select either smooth or pixelated image sampling.
   - This will make it easier to inspect the sample images and the heatmaps: when the sample images and heatmaps are small, smoothing the image could potentially smear out important details, while pixelating large images could potentially hide small details.
   - The documentation was updated to include this new feature. As the feature caused some changes in the UI, the screenshots in the documentation were updated as well.
+- Fixed the alternative text of the sample and heatmap images in the sample viewer. Previously, the text was `[Object object]`, which is the default string that is returned when the `toString` method of an object is called. The alternative text of the sample images and heatmaps is generated from their sample labels. The problem was, that the labels were not strings, but objects containing the label index, the WordNetId, and the human-readable name of the label.
 - The frontend project was updated to Angular 19.2, Clarity Design System 6.15, and Clarity 17.9.
 - The dependencies and the development dependencies of the frontend project were updated to their respective latest versions.
 - The dependencies of the Node.js-based linters were updated to their respective latest versions.

--- a/source/frontend/services/attributions/attribution.ts
+++ b/source/frontend/services/attributions/attribution.ts
@@ -1,4 +1,5 @@
 
+import { Label, LabelJson } from '@services/datasets/label';
 import { ServiceException } from '@services/service-exception';
 
 /**
@@ -23,7 +24,7 @@ export class Attribution {
         }
 
         this.index = attribution.index;
-        this.labels = attribution.labels;
+        this.labels = attribution.labels.map(label => new Label(label));
         this.prediction = attribution.prediction;
         this.width = attribution.width;
         this.height = attribution.height;
@@ -49,7 +50,7 @@ export class Attribution {
     /**
      * Gets or sets the true labels of the dataset sample for which the attribution was generated.
      */
-    public accessor labels: string | string[];
+    public accessor labels: Label[];
 
     /**
      * Gets a comma-separated list of all labels, which can be used for displaying the labels.
@@ -57,10 +58,23 @@ export class Attribution {
      * @returns {string} Returns a string containing a comma-separated list of all labels.
      */
     public get labelDisplay(): string {
-        if (Array.isArray(this.labels)) {
-            return this.labels.join(', ');
+        if (this.labels.length === 0) {
+            return '';
         }
-        return this.labels;
+
+        if (this.labels.length === 1) {
+            return this.labels[0].name;
+        }
+
+        if (this.labels.length === 2) {
+            return `${this.labels[0].name} and ${this.labels[1].name}`;
+        }
+
+        return this.labels
+            .slice(0, this.labels.length - 1)
+            .map(label => label.name)
+            .join(', ')
+            .concat(' and ', this.labels[this.labels.length - 1].name);
     }
 
     /**
@@ -108,7 +122,7 @@ export interface AttributionJson {
     /**
      * Contains the true labels of the dataset sample for which the attribution was generated.
      */
-    labels: string | string[];
+    labels: LabelJson[];
 
     /**
      * Contains the output of the model for the dataset sample for which the attribution was generated.

--- a/source/frontend/services/color-maps/color-map.ts
+++ b/source/frontend/services/color-maps/color-map.ts
@@ -14,7 +14,7 @@ export class ColorMap {
      * @param {ColorMapJson} colorMap The JSON object that was retrieved from the backend REST API.
      * @param {string} baseUrl The base URL that is added to the heatmap URLs.
      *
-     * @throws {ServiceException} The analysis category is <code>null</code> or <code>undefined</code>.
+     * @throws {ServiceException} The color map is <code>null</code> or <code>undefined</code>.
      */
     public constructor(colorMap?: ColorMapJson, baseUrl?: string) {
 

--- a/source/frontend/services/datasets/label.ts
+++ b/source/frontend/services/datasets/label.ts
@@ -1,0 +1,74 @@
+
+import { ServiceException } from '@services/service-exception';
+
+/**
+ * Represents a label of a dataset sample.
+ */
+export class Label {
+
+    // #region Constructor
+
+    /**
+     * Initializes a new Label instance.
+     *
+     * @param {LabelJson} label The JSON object that was retrieved from the backend REST API.
+     *
+     * @throws {ServiceException} The label is <code>null</code> or <code>undefined</code>.
+     */
+    public constructor(label?: LabelJson) {
+
+        if (!label) {
+            throw new ServiceException('Datasets', { message: 'The dataset sample label could not be loaded from the received JSON.'});
+        }
+
+        this.index = label.index;
+        this.wordNetId = label.wordNetId;
+        this.name = label.name;
+    }
+
+    // #endregion
+
+    // #region Public Properties
+
+    /**
+     * Gets or sets the index of the output neuron that corresponds to the label.
+     */
+    public accessor index: number;
+
+    /**
+     * Gets or sets the WordNet ID of the synset that describes the label (this is only necessary for some datasets like ImageNet).
+     */
+    public accessor wordNetId: string;
+
+    /**
+     * Gets or sets the human-readable name of the label.
+     */
+    public accessor name: string;
+
+    // #endregion
+}
+
+/**
+ * Represents an interface for the JSON objects that contain the information about a dataset sample label and are retrieved from the REST API.
+ */
+export interface LabelJson {
+
+    // #region Fields
+
+    /**
+     * Contains the index of the output neuron that corresponds to the label.
+     */
+    index: number;
+
+    /**
+     * Contains the WordNet ID of the synset that describes the label (this is only necessary for some datasets like ImageNet).
+     */
+    wordNetId: string;
+
+    /**
+     * Contains the human-readable name of the label.
+     */
+    name: string;
+
+    // #endregion
+}

--- a/source/frontend/services/datasets/sample.ts
+++ b/source/frontend/services/datasets/sample.ts
@@ -1,4 +1,5 @@
 
+import { Label, LabelJson } from '@services/datasets/label';
 import { ServiceException } from '@services/service-exception';
 
 /**
@@ -14,7 +15,7 @@ export class Sample {
      * @param {SampleJson} sample The JSON object that was retrieved from the backend REST API.
      * @param {string}  baseUrl The base URL that is added to the image URL.
      *
-     * @throws {ServiceException} The analysis category is <code>null</code> or <code>undefined</code>.
+     * @throws {ServiceException} The sample is <code>null</code> or <code>undefined</code>.
      */
     public constructor(sample?: SampleJson, baseUrl?: string) {
 
@@ -23,7 +24,7 @@ export class Sample {
         }
 
         this.index = sample.index;
-        this.labels = sample.labels;
+        this.labels = sample.labels.map(label => new Label(label));
         this.width = sample.width;
         this.height = sample.height;
         this.url = sample.url;
@@ -44,16 +45,29 @@ export class Sample {
     /**
      * Gets or sets the true labels of the dataset sample.
      */
-    public accessor labels: string | string[];
+    public accessor labels: Label[];
 
     /**
      * Gets a comma-separated list of all labels, which can be used for displaying the labels.
      */
     public get labelDisplay(): string {
-        if (Array.isArray(this.labels)) {
-            return this.labels.join(', ');
+        if (this.labels.length === 0) {
+            return '';
         }
-        return this.labels;
+
+        if (this.labels.length === 1) {
+            return this.labels[0].name;
+        }
+
+        if (this.labels.length === 2) {
+            return `${this.labels[0].name} and ${this.labels[1].name}`;
+        }
+
+        return this.labels
+            .slice(0, this.labels.length - 1)
+            .map(label => label.name)
+            .join(', ')
+            .concat(' and ', this.labels[this.labels.length - 1].name);
     }
 
     /**
@@ -96,7 +110,7 @@ export interface SampleJson {
     /**
      * Contains the true labels of the dataset sample.
      */
-    labels: string | string[];
+    labels: LabelJson[];
 
     /**
      * Contains the width of the sample image.


### PR DESCRIPTION
Fixed the alternative text of the sample and heatmap images in the sample viewer. Previously, the text was `[Object object]`, which is the default string that is returned when the `toString` method of an object is called. The alternative text of the sample images and heatmaps is generated from their sample labels. The problem was, that the labels were not strings, but objects containing the label index, the WordNetId, and the human-readable name of the label.

Closes issue #77.