### PR TITLE
Fixed the Deploy GitHub Actions Workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -58,4 +58,4 @@ jobs:
       - name: Build the ViRelAy Project
         run: uv --directory source/backend build
       - name: Publish the ViRelAy Project to PyPI
-        run: uv --directory source/backend publish --repository pypi
+        run: uv --directory source/backend publish


### PR DESCRIPTION
The deployment workflow failed due to an extra argument that was added to the `uv publish` command. This commit removes the extra argument and hopefully fixes the workflow.

Closes issue #83.