### PR TITLE
Re-Release v0.5.0

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -58,4 +58,4 @@ jobs:
       - name: Build the ViRelAy Project
         run: uv --directory source/backend build
       - name: Publish the ViRelAy Project to PyPI
-        run: uv --directory source/backend publish --repository pypi
+        run: uv --directory source/backend publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ## v0.5.0
 
-*Release date to be determined.*
+*Released on April 10, 2025.*
 
 ### General
 
-- Set up a new GitHub Actions workflow that automatically publishes the ViRelAy package to the Python Package Index (PyPI) when a new release is created on GitHub.
 - Added a CSpell configuration for spell-checking the contents of the repository, checked all files, and corrected all spelling mistakes.
 - Removed the `LICENSE` file. Previously, there were two license files: `COPYING`, which contained the AGPL 3.0 license text, and `LICENSE`, which contained a note about where to find the license of the project and any third-party licenses. This was done, because GPL prefers the file name `COPYING`, but back then GitHub did not support that file name. Now, GitHub also supports `COPYING`. As the information about where to find the project license and the third-party licenses is also contained in the read me, the `LICENSE` file was removed.
 - Added a `CITATION.cff` file, which contains the necessary information to cite this repository. This file is based on the [Citation File Format (CFF)](https://citation-file-format.github.io) standard.
@@ -111,6 +110,7 @@
   - Instead of using the `setup-python` action, we now use the `astral-sh/setup-uv` action to install uv, which is then used to install Python, which means that the exact same Python version that is used locally is also used in the CI/CD pipeline.
   - The `jobs.docs.strategy.fail-fast` option was previously used to prevent the workflow from stopping if the documentation build failed. However, this option is only supported for matrix strategies. Since the `docs` job does not use a matrix strategy, the `jobs.docs.strategy.fail-fast` option was replaced with the `jobs.docs.continue-on-error` option.
 - The spell-checking was also added to the GitHub Actions tests workflow. This will run the spell-checking on all files in the repository and report any misspelled words during the CI/CD process.
+- Set up a new GitHub Actions workflow that automatically publishes the ViRelAy package to the Python Package Index (PyPI) when a new release is created on GitHub.
 
 ### Documentation
 


### PR DESCRIPTION
This is a re-release of v0.5.0, because the CI/CD pipeline failed to publish the ViRelAy package to PyPI. Hopefully, this time it will work.

Closes issues #83 and #85.