### PR TITLE
Updated the Release Date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.0
 
-*Release date to be determined.*
+*Released on April 15, 2025.*
 
 ### Backend REST API Updates in v0.6.0
 


### PR DESCRIPTION
Updated the release date of the 0.6.0 version in the changelog to April 15, 2025.

Closes issue #88.