### PR TITLE
Renamed the "master" branch to "main"

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,9 +4,9 @@ name: ViRelAy Continuous Deployment
 
 # This workflow will run when a new release is created on GitHub, the process works like this:
 #   1) For each milestone multiple issues are created)
-#   2) For each issue a new branch is branched off from the develop branch (which itself is branched off from master)
+#   2) For each issue a new branch is branched off from the develop branch (which itself is branched off from main)
 #   3) When the issue is resolved, a pull request is created to merge the issue branch into the develop branch
-#   4) Once all issues for a milestone are resolved, a pull request is created to merge the develop branch into the master branch
+#   4) Once all issues for a milestone are resolved, a pull request is created to merge the develop branch into the main branch
 #   5) When the pull request is merged, a new release is created
 #   6) This workflow will then be triggered and the ViRelAy project will be built and published to PyPI
 on:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,15 +2,15 @@
 # This workflow will run the unit tests, the linters, the static type checker, the spell checker, and will build the documentation
 name: ViRelAy Continuous Integration
 
-# This workflow runs when commits are pushed to the master/develop branch or when a pull request for the master/develop branch is opened or pushed to
+# This workflow runs when commits are pushed to the main/develop branch or when a pull request for the main/develop branch is opened or pushed to
 on:
   push:
     branches:
-      - master
+      - main
       - develop
   pull_request:
     branches:
-      - master
+      - main
       - develop
 
 # This workflow contains multiple jobs for unit testing, linting, type checking, spell checking, and building

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.6.1
+
+*Released on April 15, 2025.*
+
+### General
+
+- Renamed the `master` branch to `main` in order to avoid any links to sensitive topics.
+  - All references to the `master` branch in the repository were updated to `main`.
+
 ## v0.6.0
 
 *Released on April 15, 2025.*

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,12 +68,12 @@ def get_latest_git_tag() -> str:
     """Retrieves the latest Git tag in the source code repository.
 
     Returns:
-        str: Returns the name of the latest Git tag in the source code repository. If no tags are available, then "master" is returned.
+        str: Returns the name of the latest Git tag in the source code repository. If no tags are available, then "main" is returned.
     """
 
     # Tries to get the most recent tag in the source code repository using the git describe command, which returns the
-    # closest tag that can be reached from the specified revision, which in this case is the latest commit on master,
-    # if no tags are available, then "master" is returned as a fallback
+    # closest tag that can be reached from the specified revision, which in this case is the latest commit on main,
+    # if no tags are available, then "main" is returned as a fallback
     try:
         return run(
             ['git', 'describe', '--tags', 'HEAD'],
@@ -82,7 +82,7 @@ def get_latest_git_tag() -> str:
             text=True
         ).stdout[:-1]
     except CalledProcessError:
-        return 'master'
+        return 'main'
 
 
 def get_object_by_name(name: str, module: ModuleType) -> ModuleType | type[Any] | None:

--- a/docs/source/getting-started/example-project.rst
+++ b/docs/source/getting-started/example-project.rst
@@ -10,9 +10,9 @@ If you installed ViRelAy from the project's Git repository, then you already hav
 
     $ mkdir -p virelay-example/test-project
     $ cd virelay-example
-    $ curl -o 'meta_analysis.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/meta_analysis.py'
-    $ curl -o 'make_project.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/make_project.py'
-    $ curl -o 'make_test_data.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/test-project/make_test_data.py'
+    $ curl -o 'meta_analysis.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/meta_analysis.py'
+    $ curl -o 'make_project.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/make_project.py'
+    $ curl -o 'make_test_data.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/test-project/make_test_data.py'
 
 The test project scripts require CoRelAy to be installed, which is also available on PyPI and can be installed using your favorite Python package manager, e.g., ``pip``. If you use ``pip`` it is recommended to create a virtual environment in order to not pollute your base environment. The test project scripts support many different clustering and embedding methods. To use the UMAP embedding method and the HDBSCAN clustering method, optional support for them has to be installed as well. Using ``pip``, this can be done like so:
 

--- a/docs/source/user-guide/how-to-create-a-project.rst
+++ b/docs/source/user-guide/how-to-create-a-project.rst
@@ -31,11 +31,11 @@ Alternatively, if you installed ViRelAy using PyPI, you can retrieve the latest 
 
     $ mkdir vgg16-project
     $ cd vgg16-project
-    $ curl -o 'meta_analysis.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/meta_analysis.py'
-    $ curl -o 'make_project.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/make_project.py'
-    $ curl -o 'train_vgg.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/vgg16-project/train_vgg.py'
-    $ curl -o 'explain_vgg.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/vgg16-project/explain_vgg.py'
-    $ curl -o 'make_dataset.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/vgg16-project/make_dataset.py'
+    $ curl -o 'meta_analysis.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/meta_analysis.py'
+    $ curl -o 'make_project.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/make_project.py'
+    $ curl -o 'train_vgg.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/vgg16-project/train_vgg.py'
+    $ curl -o 'explain_vgg.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/vgg16-project/explain_vgg.py'
+    $ curl -o 'make_dataset.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/vgg16-project/make_dataset.py'
 
 The scripts ``meta_analysis.py`` and ``make_project.py``, available under :repo:`docs/examples`, are general-purpose scripts for performing a meta-analysis and creating a ViRelAy project file, which can be used as a starting point for any project. In contrast, the scripts ``train_vgg.py``, ``explain_vgg.py``, and ``make_dataset.py``, available under :repo:`docs/examples/vgg16-project`, are tailored specifically to this VGG16 project but can serve as a blueprint for your own projects. These scripts include:
 

--- a/source/backend/pyproject.toml
+++ b/source/backend/pyproject.toml
@@ -76,7 +76,7 @@ classifiers = [
 Documentation = "https://virelay.readthedocs.io/en/latest/"
 Repository = "https://github.com/virelay/virelay.git"
 Issues = "https://github.com/virelay/virelay/issues"
-Changelog = "https://github.com/virelay/virelay/blob/master/CHANGELOG.md"
+Changelog = "https://github.com/virelay/virelay/blob/main/CHANGELOG.md"
 
 # Entrypoints for the project (these are installed as scripts when the package is installed)
 [project.scripts]


### PR DESCRIPTION
The "master" branch was renamed to "main". All references to the "master" branch in the repository have been updated to point to "main".

Closes issue #92.