### PR TITLE
Updated the GitHub URLs in the Read Me

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Renamed the `master` branch to `main` in order to avoid any links to sensitive topics.
   - All references to the `master` branch in the repository were updated to `main`.
+- Changed the URLs in the read me that point to the GitHub repository to be absolute URLs, which is necessary, because PyPI cannot resolve the relative GitHub URLs. This means that the images are not displayed in the read me and the links cannot be clicked.
+  - Some of the images in the read me use a feature of GitHub, which allows to display different images based on whether GitHub is in dark mode or light mode. This feature is not supported by PyPI, so both images are displayed in PyPI, which is not ideal. Fortunately, we are already using the Hatch Fancy PyPI Readme plugin for Hatchling, which allows us to make substitutions in the read me. The pyproject.toml configuration was updated to remove any dark-mode-only images in the read me. PyPI only has a light mode, so the light-mode-only images remain in the read me.
 
 ## v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <tr>
 <td align="center" width="1182px">
 
-<img src="design/virelay-logo-with-title.png" alt="ViRelAy Logo"/>
+<img src="https://raw.githubusercontent.com/virelay/virelay/refs/heads/main/design/virelay-logo-with-title.png" alt="ViRelAy Logo"/>
 
 # Visualizing Relevance Analyses
 
@@ -19,8 +19,8 @@
 </tbody>
 </table>
 
-![ViRelAy Light Mode UI](design/virelay-light-mode-ui.png#gh-light-mode-only)
-![ViRelAy Dark Mode UI](design/virelay-dark-mode-ui.png#gh-dark-mode-only)
+![ViRelAy Light Mode UI](https://raw.githubusercontent.com/virelay/virelay/refs/heads/main/design/virelay-light-mode-ui.png#gh-light-mode-only)
+![ViRelAy Dark Mode UI](https://raw.githubusercontent.com/virelay/virelay/refs/heads/main/design/virelay-dark-mode-ui.png#gh-dark-mode-only)
 
 For more information about ViRelAy, getting started guides, in-depth tutorials, and API documentation, please refer to the [documentation](https://virelay.readthedocs.io/en/latest/).
 
@@ -83,7 +83,7 @@ To unlock faster performance and scalability, we recommend running ViRelAy with 
 
 ## Contributing
 
-If you would like to contribute, there are multiple ways you can help out. If you find a bug or have a feature request, please feel free to [open an issue on GitHub](https://github.com/virelay/virelay/issues). If you want to contribute code, please [fork the repository](https://github.com/virelay/virelay/fork) and use a feature branch. Pull requests are always welcome. Before forking, please open an issue where you describe what you want to do. This helps to align your ideas with ours and may prevent you from doing work, that we are already planning on doing. If you have contributed to the project, please add yourself to the [contributors list](CONTRIBUTORS.md).
+If you would like to contribute, there are multiple ways you can help out. If you find a bug or have a feature request, please feel free to [open an issue on GitHub](https://github.com/virelay/virelay/issues). If you want to contribute code, please [fork the repository](https://github.com/virelay/virelay/fork) and use a feature branch. Pull requests are always welcome. Before forking, please open an issue where you describe what you want to do. This helps to align your ideas with ours and may prevent you from doing work, that we are already planning on doing. If you have contributed to the project, please add yourself to the [contributors list](https://github.com/virelay/virelay/blob/main/CONTRIBUTORS.md).
 
 To help speed up the merging of your pull request, please comment and document your code extensively, try to emulate the coding style of the project, and update the documentation if necessary.
 
@@ -91,4 +91,4 @@ For more information on how to contribute, please refer to our [contributor's gu
 
 ## License
 
-ViRelAy is licensed under the [GNU Affero General Public License Version 3 (AGPL v3)](https://www.gnu.org/licenses/agpl-3.0.html) later. For more information see the [license](COPYING). For licenses of bundled third party software packages please refer to the [3rd party license list](/source/frontend/distribution/3rdpartylicenses.txt), which is available after [building the frontend](https://virelay.readthedocs.io/en/latest/contributors-guide/frontend.html#building-the-frontend).
+ViRelAy is licensed under the [GNU Affero General Public License Version 3 (AGPL v3)](https://www.gnu.org/licenses/agpl-3.0.html) later. For more information see the [license](https://github.com/virelay/virelay/blob/main/COPYING). For licenses of bundled third party software packages please refer to the 3rd party license list, which is available in `source/frontend/distribution/3rdpartylicenses.txt` after [building the frontend](https://virelay.readthedocs.io/en/latest/contributors-guide/frontend.html#building-the-frontend).

--- a/source/backend/pyproject.toml
+++ b/source/backend/pyproject.toml
@@ -135,11 +135,15 @@ raw-options = { root = "../.." }
 version-file = "virelay/version.py"
 
 # Configures the Hatch Fancy PyPI Readme plugin to compose the content of the read me file from the project's read me file, which is located in the
-# root directory of the repository
+# root directory of the repository; any dark-mode-only images are removed from the read me file, because this is a feature only supported by GitHub,
+# PyPI would display both images in the read me file; since PyPI only has a light mode, the light-mode-only images remain in the read me file
 [tool.hatch.metadata.hooks.fancy-pypi-readme]
 content-type = "text/markdown"
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
 path = "../../README.md"
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '\!\[[^\]]+\]\([^\)]+#gh-dark-mode-only\)\n?'
+replacement = ''
 
 # Configures the hatch-build-script plugin, which uses build hooks to run arbitrary build scripts during the build of the project; this is used to
 # the Angular frontend of the project and include its files in the source distribution (the wheel will be build by extracting the source distribution

--- a/source/frontend/package-lock.json
+++ b/source/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@virelay/frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@virelay/frontend",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@angular/animations": "^19.2.5",
@@ -47,7 +47,7 @@
     },
     "../../tests/eslint": {
       "name": "@virelay/eslint-config",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
@@ -67,7 +67,7 @@
     },
     "../../tests/stylelint": {
       "name": "@virelay/stylelint-config",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/source/frontend/package.json
+++ b/source/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virelay/frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "ViRelAy is an XAI visualization tool for the analysis of the results of spectral relevance analysis (SpRAy) pipelines.",
   "keywords": [
     "ViRelAy",

--- a/tests/cspell/package.json
+++ b/tests/cspell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virelay/cspell-config",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The CSpell configuration for ViRelAy.",
   "author": {
     "name": "David Neumann",

--- a/tests/eslint/package.json
+++ b/tests/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virelay/eslint-config",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The ESLint configuration for ViRelAy. Having the configuration in a separate package makes it easier to use in a monorepo.",
   "author": {
     "name": "David Neumann",

--- a/tests/markdownlint/package.json
+++ b/tests/markdownlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virelay/markdownlint-config",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The MarkdownLint configuration for ViRelAy.",
   "author": {
     "name": "David Neumann",

--- a/tests/stylelint/package.json
+++ b/tests/stylelint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virelay/stylelint-config",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The StyleLint configuration for ViRelAy. Having the configuration in a separate package makes it easier to use in a monorepo.",
   "author": {
     "name": "David Neumann",


### PR DESCRIPTION
Changed the URLs in the read me that point to the GitHub repository to be absolute URLs, which is necessary, because PyPI cannot resolve the relative GitHub URLs. This means that the images are not displayed in the read me and the links cannot be clicked.

Some of the images in the read me use a feature of GitHub, which allows to display different images based on whether GitHub is in dark mode or light mode. This feature is not supported by PyPI, so both images are displayed in PyPI, which is not ideal. Fortunately, we are already using the Hatch Fancy PyPI Readme plugin for Hatchling, which allows us to make substitutions in the read me. The pyproject.toml configuration was updated to remove any dark-mode-only images in the read me. PyPI only has a light mode, so the light-mode-only images remain in the read me.

Also, the version of the project was updated from 0.6.0 to 0.6.1, in preparation for the next release. The changelog was updated to reflect the changes made.

Closes issue #91.