### PR TITLE
Release v0.6.1

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,9 +4,9 @@ name: ViRelAy Continuous Deployment
 
 # This workflow will run when a new release is created on GitHub, the process works like this:
 #   1) For each milestone multiple issues are created)
-#   2) For each issue a new branch is branched off from the develop branch (which itself is branched off from master)
+#   2) For each issue a new branch is branched off from the develop branch (which itself is branched off from main)
 #   3) When the issue is resolved, a pull request is created to merge the issue branch into the develop branch
-#   4) Once all issues for a milestone are resolved, a pull request is created to merge the develop branch into the master branch
+#   4) Once all issues for a milestone are resolved, a pull request is created to merge the develop branch into the main branch
 #   5) When the pull request is merged, a new release is created
 #   6) This workflow will then be triggered and the ViRelAy project will be built and published to PyPI
 on:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,15 +2,15 @@
 # This workflow will run the unit tests, the linters, the static type checker, the spell checker, and will build the documentation
 name: ViRelAy Continuous Integration
 
-# This workflow runs when commits are pushed to the master/develop branch or when a pull request for the master/develop branch is opened or pushed to
+# This workflow runs when commits are pushed to the main/develop branch or when a pull request for the main/develop branch is opened or pushed to
 on:
   push:
     branches:
-      - master
+      - main
       - develop
   pull_request:
     branches:
-      - master
+      - main
       - develop
 
 # This workflow contains multiple jobs for unit testing, linting, type checking, spell checking, and building

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Renamed the `master` branch to `main` in order to avoid any links to sensitive topics.
   - All references to the `master` branch in the repository were updated to `main`.
+- Changed the URLs in the read me that point to the GitHub repository to be absolute URLs, which is necessary, because PyPI cannot resolve the relative GitHub URLs. This means that the images are not displayed in the read me and the links cannot be clicked.
+  - Some of the images in the read me use a feature of GitHub, which allows to display different images based on whether GitHub is in dark mode or light mode. This feature is not supported by PyPI, so both images are displayed in PyPI, which is not ideal. Fortunately, we are already using the Hatch Fancy PyPI Readme plugin for Hatchling, which allows us to make substitutions in the read me. The pyproject.toml configuration was updated to remove any dark-mode-only images in the read me. PyPI only has a light mode, so the light-mode-only images remain in the read me.
 
 ## v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.6.1
+
+*Released on April 15, 2025.*
+
+### General
+
+- Renamed the `master` branch to `main` in order to avoid any links to sensitive topics.
+  - All references to the `master` branch in the repository were updated to `main`.
+
 ## v0.6.0
 
 *Released on April 15, 2025.*

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <tr>
 <td align="center" width="1182px">
 
-<img src="design/virelay-logo-with-title.png" alt="ViRelAy Logo"/>
+<img src="https://raw.githubusercontent.com/virelay/virelay/refs/heads/main/design/virelay-logo-with-title.png" alt="ViRelAy Logo"/>
 
 # Visualizing Relevance Analyses
 
@@ -19,8 +19,8 @@
 </tbody>
 </table>
 
-![ViRelAy Light Mode UI](design/virelay-light-mode-ui.png#gh-light-mode-only)
-![ViRelAy Dark Mode UI](design/virelay-dark-mode-ui.png#gh-dark-mode-only)
+![ViRelAy Light Mode UI](https://raw.githubusercontent.com/virelay/virelay/refs/heads/main/design/virelay-light-mode-ui.png#gh-light-mode-only)
+![ViRelAy Dark Mode UI](https://raw.githubusercontent.com/virelay/virelay/refs/heads/main/design/virelay-dark-mode-ui.png#gh-dark-mode-only)
 
 For more information about ViRelAy, getting started guides, in-depth tutorials, and API documentation, please refer to the [documentation](https://virelay.readthedocs.io/en/latest/).
 
@@ -83,7 +83,7 @@ To unlock faster performance and scalability, we recommend running ViRelAy with 
 
 ## Contributing
 
-If you would like to contribute, there are multiple ways you can help out. If you find a bug or have a feature request, please feel free to [open an issue on GitHub](https://github.com/virelay/virelay/issues). If you want to contribute code, please [fork the repository](https://github.com/virelay/virelay/fork) and use a feature branch. Pull requests are always welcome. Before forking, please open an issue where you describe what you want to do. This helps to align your ideas with ours and may prevent you from doing work, that we are already planning on doing. If you have contributed to the project, please add yourself to the [contributors list](CONTRIBUTORS.md).
+If you would like to contribute, there are multiple ways you can help out. If you find a bug or have a feature request, please feel free to [open an issue on GitHub](https://github.com/virelay/virelay/issues). If you want to contribute code, please [fork the repository](https://github.com/virelay/virelay/fork) and use a feature branch. Pull requests are always welcome. Before forking, please open an issue where you describe what you want to do. This helps to align your ideas with ours and may prevent you from doing work, that we are already planning on doing. If you have contributed to the project, please add yourself to the [contributors list](https://github.com/virelay/virelay/blob/main/CONTRIBUTORS.md).
 
 To help speed up the merging of your pull request, please comment and document your code extensively, try to emulate the coding style of the project, and update the documentation if necessary.
 
@@ -91,4 +91,4 @@ For more information on how to contribute, please refer to our [contributor's gu
 
 ## License
 
-ViRelAy is licensed under the [GNU Affero General Public License Version 3 (AGPL v3)](https://www.gnu.org/licenses/agpl-3.0.html) later. For more information see the [license](COPYING). For licenses of bundled third party software packages please refer to the [3rd party license list](/source/frontend/distribution/3rdpartylicenses.txt), which is available after [building the frontend](https://virelay.readthedocs.io/en/latest/contributors-guide/frontend.html#building-the-frontend).
+ViRelAy is licensed under the [GNU Affero General Public License Version 3 (AGPL v3)](https://www.gnu.org/licenses/agpl-3.0.html) later. For more information see the [license](https://github.com/virelay/virelay/blob/main/COPYING). For licenses of bundled third party software packages please refer to the 3rd party license list, which is available in `source/frontend/distribution/3rdpartylicenses.txt` after [building the frontend](https://virelay.readthedocs.io/en/latest/contributors-guide/frontend.html#building-the-frontend).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,12 +68,12 @@ def get_latest_git_tag() -> str:
     """Retrieves the latest Git tag in the source code repository.
 
     Returns:
-        str: Returns the name of the latest Git tag in the source code repository. If no tags are available, then "master" is returned.
+        str: Returns the name of the latest Git tag in the source code repository. If no tags are available, then "main" is returned.
     """
 
     # Tries to get the most recent tag in the source code repository using the git describe command, which returns the
-    # closest tag that can be reached from the specified revision, which in this case is the latest commit on master,
-    # if no tags are available, then "master" is returned as a fallback
+    # closest tag that can be reached from the specified revision, which in this case is the latest commit on main,
+    # if no tags are available, then "main" is returned as a fallback
     try:
         return run(
             ['git', 'describe', '--tags', 'HEAD'],
@@ -82,7 +82,7 @@ def get_latest_git_tag() -> str:
             text=True
         ).stdout[:-1]
     except CalledProcessError:
-        return 'master'
+        return 'main'
 
 
 def get_object_by_name(name: str, module: ModuleType) -> ModuleType | type[Any] | None:

--- a/docs/source/getting-started/example-project.rst
+++ b/docs/source/getting-started/example-project.rst
@@ -10,9 +10,9 @@ If you installed ViRelAy from the project's Git repository, then you already hav
 
     $ mkdir -p virelay-example/test-project
     $ cd virelay-example
-    $ curl -o 'meta_analysis.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/meta_analysis.py'
-    $ curl -o 'make_project.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/make_project.py'
-    $ curl -o 'make_test_data.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/test-project/make_test_data.py'
+    $ curl -o 'meta_analysis.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/meta_analysis.py'
+    $ curl -o 'make_project.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/make_project.py'
+    $ curl -o 'make_test_data.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/test-project/make_test_data.py'
 
 The test project scripts require CoRelAy to be installed, which is also available on PyPI and can be installed using your favorite Python package manager, e.g., ``pip``. If you use ``pip`` it is recommended to create a virtual environment in order to not pollute your base environment. The test project scripts support many different clustering and embedding methods. To use the UMAP embedding method and the HDBSCAN clustering method, optional support for them has to be installed as well. Using ``pip``, this can be done like so:
 

--- a/docs/source/user-guide/how-to-create-a-project.rst
+++ b/docs/source/user-guide/how-to-create-a-project.rst
@@ -31,11 +31,11 @@ Alternatively, if you installed ViRelAy using PyPI, you can retrieve the latest 
 
     $ mkdir vgg16-project
     $ cd vgg16-project
-    $ curl -o 'meta_analysis.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/meta_analysis.py'
-    $ curl -o 'make_project.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/make_project.py'
-    $ curl -o 'train_vgg.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/vgg16-project/train_vgg.py'
-    $ curl -o 'explain_vgg.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/vgg16-project/explain_vgg.py'
-    $ curl -o 'make_dataset.py' 'https://raw.githubusercontent.com/virelay/virelay/master/docs/examples/vgg16-project/make_dataset.py'
+    $ curl -o 'meta_analysis.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/meta_analysis.py'
+    $ curl -o 'make_project.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/make_project.py'
+    $ curl -o 'train_vgg.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/vgg16-project/train_vgg.py'
+    $ curl -o 'explain_vgg.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/vgg16-project/explain_vgg.py'
+    $ curl -o 'make_dataset.py' 'https://raw.githubusercontent.com/virelay/virelay/main/docs/examples/vgg16-project/make_dataset.py'
 
 The scripts ``meta_analysis.py`` and ``make_project.py``, available under :repo:`docs/examples`, are general-purpose scripts for performing a meta-analysis and creating a ViRelAy project file, which can be used as a starting point for any project. In contrast, the scripts ``train_vgg.py``, ``explain_vgg.py``, and ``make_dataset.py``, available under :repo:`docs/examples/vgg16-project`, are tailored specifically to this VGG16 project but can serve as a blueprint for your own projects. These scripts include:
 

--- a/source/backend/pyproject.toml
+++ b/source/backend/pyproject.toml
@@ -135,11 +135,15 @@ raw-options = { root = "../.." }
 version-file = "virelay/version.py"
 
 # Configures the Hatch Fancy PyPI Readme plugin to compose the content of the read me file from the project's read me file, which is located in the
-# root directory of the repository
+# root directory of the repository; any dark-mode-only images are removed from the read me file, because this is a feature only supported by GitHub,
+# PyPI would display both images in the read me file; since PyPI only has a light mode, the light-mode-only images remain in the read me file
 [tool.hatch.metadata.hooks.fancy-pypi-readme]
 content-type = "text/markdown"
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
 path = "../../README.md"
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '\!\[[^\]]+\]\([^\)]+#gh-dark-mode-only\)\n?'
+replacement = ''
 
 # Configures the hatch-build-script plugin, which uses build hooks to run arbitrary build scripts during the build of the project; this is used to
 # the Angular frontend of the project and include its files in the source distribution (the wheel will be build by extracting the source distribution

--- a/source/backend/pyproject.toml
+++ b/source/backend/pyproject.toml
@@ -76,7 +76,7 @@ classifiers = [
 Documentation = "https://virelay.readthedocs.io/en/latest/"
 Repository = "https://github.com/virelay/virelay.git"
 Issues = "https://github.com/virelay/virelay/issues"
-Changelog = "https://github.com/virelay/virelay/blob/master/CHANGELOG.md"
+Changelog = "https://github.com/virelay/virelay/blob/main/CHANGELOG.md"
 
 # Entrypoints for the project (these are installed as scripts when the package is installed)
 [project.scripts]

--- a/source/frontend/package-lock.json
+++ b/source/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@virelay/frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@virelay/frontend",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@angular/animations": "^19.2.5",
@@ -47,7 +47,7 @@
     },
     "../../tests/eslint": {
       "name": "@virelay/eslint-config",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
@@ -67,7 +67,7 @@
     },
     "../../tests/stylelint": {
       "name": "@virelay/stylelint-config",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/source/frontend/package.json
+++ b/source/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virelay/frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "ViRelAy is an XAI visualization tool for the analysis of the results of spectral relevance analysis (SpRAy) pipelines.",
   "keywords": [
     "ViRelAy",

--- a/tests/cspell/package.json
+++ b/tests/cspell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virelay/cspell-config",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The CSpell configuration for ViRelAy.",
   "author": {
     "name": "David Neumann",

--- a/tests/eslint/package.json
+++ b/tests/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virelay/eslint-config",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The ESLint configuration for ViRelAy. Having the configuration in a separate package makes it easier to use in a monorepo.",
   "author": {
     "name": "David Neumann",

--- a/tests/markdownlint/package.json
+++ b/tests/markdownlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virelay/markdownlint-config",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The MarkdownLint configuration for ViRelAy.",
   "author": {
     "name": "David Neumann",

--- a/tests/stylelint/package.json
+++ b/tests/stylelint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virelay/stylelint-config",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The StyleLint configuration for ViRelAy. Having the configuration in a separate package makes it easier to use in a monorepo.",
   "author": {
     "name": "David Neumann",


### PR DESCRIPTION
## General

- Renamed the `master` branch to `main` in order to avoid any links to sensitive topics.
  - All references to the `master` branch in the repository were updated to `main`.
- Changed the URLs in the read me that point to the GitHub repository to be absolute URLs, which is necessary, because PyPI cannot resolve the relative GitHub URLs. This means that the images are not displayed in the read me and the links cannot be clicked.
  - Some of the images in the read me use a feature of GitHub, which allows to display different images based on whether GitHub is in dark mode or light mode. This feature is not supported by PyPI, so both images are displayed in PyPI, which is not ideal. Fortunately, we are already using the Hatch Fancy PyPI Readme plugin for Hatchling, which allows us to make substitutions in the read me. The pyproject.toml configuration was updated to remove any dark-mode-only images in the read me. PyPI only has a light mode, so the light-mode-only images remain in the read me.

Closes issues #92 and #91.