### PR TITLE
Sorted the Python Imports Alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   - UI Source Files: Previously, there were three source files: one for the light-mode UI, one for the dark-mode UI, and one that contained a split-screen montage of both. These were all converted to a single source file that contains multiple pages, one for each UI mode (light and dark) and one for the split-screen montage.
 - Cleaned up the CSPell configuration by removing unnecessary words from its dictionary that are no longer used in the project.
 
+### Backend REST API Updates in v1.0.0
+
+- Sorted the Python imports. They are now categorized by standard library imports, third-party library imports, and local imports, each separated by a blank line. Each category is sub-categorized into regular imports and "from-imports", which are not separated by blank lines. Each sub-category is sorted alphabetically. Both the imports of the `virelay` package and the imports of the unit tests in the `tests` package were sorted.
+
 ## v0.6.1
 
 *Released on April 15, 2025.*

--- a/docs/examples/hdf5_structure.py
+++ b/docs/examples/hdf5_structure.py
@@ -65,7 +65,7 @@ def make_group_example() -> None:
             labels_group[key] = attribution_labels.astype(numpy.float32)
 
         # Predictions are the model output logits
-        attribution_predictions = numpy.array([[0, 1], [.5, .5], [1, 0]])
+        attribution_predictions = numpy.array([[0, 1], [0.5, 0.5], [1, 0]])
         predictions_group = attributions_file.require_group('prediction')
         for key, prediction in zip(attribution_keys, attribution_predictions):
             predictions_group[key] = prediction.astype(numpy.float32)
@@ -166,7 +166,7 @@ def make_dataset_example() -> None:
         attributions_file['label'] = attribution_labels.astype(numpy.float32)
 
         # Predictions are the model output logits
-        attribution_predictions = numpy.array([[0, 1], [.5, .5], [1, 0]])
+        attribution_predictions = numpy.array([[0, 1], [0.5, 0.5], [1, 0]])
         attributions_file['prediction'] = attribution_predictions.astype(numpy.float32)
 
     # Using datasets in the input/attribution does not change the analysis file structure

--- a/docs/examples/meta_analysis.py
+++ b/docs/examples/meta_analysis.py
@@ -1,19 +1,19 @@
 """Performs a meta-analysis on an attribution database and writes them into an analysis database, from which a ViRelAy project can be created."""
 
-import json
 import argparse
+import json
 
 import h5py
 import numpy
-from numpy.typing import NDArray
 from corelay.base import Param
-from corelay.processor.base import Processor
-from corelay.processor.affinity import SparseKNN
-from corelay.processor.distance import SciPyPDist
-from corelay.processor.flow import Sequential, Parallel
 from corelay.pipeline.spectral import SpectralClustering
-from corelay.processor.embedding import TSNEEmbedding, UMAPEmbedding, EigenDecomposition
-from corelay.processor.clustering import KMeans, DBSCAN, HDBSCAN, AgglomerativeClustering
+from corelay.processor.affinity import SparseKNN
+from corelay.processor.base import Processor
+from corelay.processor.clustering import AgglomerativeClustering, DBSCAN, HDBSCAN, KMeans
+from corelay.processor.distance import SciPyPDist
+from corelay.processor.embedding import EigenDecomposition, TSNEEmbedding, UMAPEmbedding
+from corelay.processor.flow import Parallel, Sequential
+from numpy.typing import NDArray
 
 
 class Flatten(Processor):

--- a/docs/examples/test-project/make_test_data.py
+++ b/docs/examples/test-project/make_test_data.py
@@ -2,9 +2,9 @@
 project for ViRelAy.
 """
 
-import os
-import json
 import argparse
+import json
+import os
 
 import h5py
 import numpy

--- a/docs/examples/vgg16-project/explain_vgg.py
+++ b/docs/examples/vgg16-project/explain_vgg.py
@@ -6,8 +6,8 @@ import h5py
 import numpy
 import torch
 from torchvision import transforms
-from torchvision.models import vgg16
 from torchvision.datasets import CIFAR10
+from torchvision.models import vgg16
 
 from zennit.attribution import Gradient
 from zennit.composites import EpsilonGammaBox

--- a/docs/examples/vgg16-project/make_dataset.py
+++ b/docs/examples/vgg16-project/make_dataset.py
@@ -1,11 +1,11 @@
 """Converts the CIFAR-10 dataset into the correct HDF5 format that is required by ViRelAy."""
 
-import json
 import argparse
+import json
 
 import h5py
-import torch
 import numpy
+import torch
 from torchvision.datasets import CIFAR10
 
 

--- a/docs/examples/vgg16-project/train_vgg.py
+++ b/docs/examples/vgg16-project/train_vgg.py
@@ -4,8 +4,8 @@ import argparse
 
 import torch
 from torchvision import transforms
-from torchvision.models import vgg16
 from torchvision.datasets import CIFAR10
+from torchvision.models import vgg16
 
 
 def train_vgg(

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,21 +2,21 @@
 
 # pylint: disable=invalid-name
 
+import inspect
 import os
 import re
 import sys
-import inspect
-from types import ModuleType
-from datetime import datetime
 from collections.abc import Sequence
+from datetime import datetime
 from subprocess import run, CalledProcessError
+from types import ModuleType
 from typing import Any, Iterator, TypeAlias, Literal
 
-from sphinx.application import Sphinx
 from pybtex.database import Entry
 from pybtex.plugin import register_plugin
-from pybtex.style.labels import BaseLabelStyle
 from pybtex.style.formatting.plain import Style as PlainStyle
+from pybtex.style.labels import BaseLabelStyle
+from sphinx.application import Sphinx
 
 
 LanguageDomain: TypeAlias = Literal['py', 'c', 'cpp', 'javascript']
@@ -54,9 +54,8 @@ def setup(app: Sphinx) -> None:
         app (Sphinx): The Sphinx application.
     """
 
-    # Sets the name of the directory into which generated documentation files are to be written and makes sure that the
-    # directory exists (this is done by signing up for the config-inited event, which is emitted when the configuration
-    # has been fully initialized)
+    # Sets the name of the directory into which generated documentation files are to be written and makes sure that the directory exists (this is done
+    # by signing up for the config-inited event, which is emitted when the configuration has been fully initialized)
     app.add_config_value('generated_path', '_generated', 'env')
     app.connect(
         'config-inited',
@@ -71,9 +70,8 @@ def get_latest_git_tag() -> str:
         str: Returns the name of the latest Git tag in the source code repository. If no tags are available, then "main" is returned.
     """
 
-    # Tries to get the most recent tag in the source code repository using the git describe command, which returns the
-    # closest tag that can be reached from the specified revision, which in this case is the latest commit on main,
-    # if no tags are available, then "main" is returned as a fallback
+    # Tries to get the most recent tag in the source code repository using the git describe command, which returns the closest tag that can be reached
+    # from the specified revision, which in this case is the latest commit on main, if no tags are available, then "main" is returned as a fallback
     try:
         return run(
             ['git', 'describe', '--tags', 'HEAD'],
@@ -289,7 +287,8 @@ project = 'ViRelAy'
 project_copyright = f'{datetime.now().year}, ViRelAy'
 author = 'ViRelAy Contributors'
 
-# Specifies the Sphinx extensions that are used by this documentation
+# Specifies the Sphinx extensions that are used by this documentation; the pybtex.style.formatting plugin is registered explicitly, which is used to
+# format citations of bibliography entries
 extensions = [
     'sphinx_copybutton',
     'sphinx_rtd_theme',
@@ -303,13 +302,14 @@ extensions = [
     'sphinxcontrib.datatemplates',
     "sphinx_new_tab_link"
 ]
+register_plugin('pybtex.style.formatting', 'author_year_style', AuthorYearStyle)
 
 # Specifies the paths for the directories that contain extra templates and static files
 templates_path = ['_templates']
 html_static_path = ['_static']
 
-# Specifies a list of patterns, relative to source directory, that match files and directories to ignore when looking
-# for source files, in this case, nothing needs to be excluded
+# Specifies a list of patterns, relative to source directory, that match files and directories to ignore when looking for source files, in this case,
+# nothing needs to be excluded
 exclude_patterns: Sequence[str] = []
 
 # Configures the theme, custom CSS rules, and the favicon that are used for the HTML pages
@@ -332,8 +332,8 @@ bibtex_bibfiles = ['bibliography.bib']
 bibtex_default_style = 'author_year_style'
 bibtex_reference_style = 'author_year'
 
-# Configures the Sphinx plugin, which shortens external Links to the GitHub repository (also, a custom formatting style
-# is registered with Pybtex, which customizes the citation labels to use the format "[<first-author> et al., <year>]")
+# Configures the Sphinx plugin, which shortens external Links to the GitHub repository (also, a custom formatting style is registered with Pybtex,
+# which customizes the citation labels to use the format "[<first-author> et al., <year>]")
 LATEST_GIT_TAG = get_latest_git_tag()
 extlinks = {
     'repo': (
@@ -341,4 +341,3 @@ extlinks = {
         '%s'
     )
 }
-register_plugin('pybtex.style.formatting', 'author_year_style', AuthorYearStyle)

--- a/source/backend/virelay/application.py
+++ b/source/backend/virelay/application.py
@@ -1,14 +1,14 @@
 """Contains the command-line interface for the ViRelAy application."""
 
-import os
-import atexit
 import argparse
+import atexit
+import os
 
 import flask
 
 from virelay import __version__
-from virelay.server import Server
 from virelay.model import Workspace
+from virelay.server import Server
 
 
 def run_cli_app() -> None:

--- a/source/backend/virelay/image_processing.py
+++ b/source/backend/virelay/image_processing.py
@@ -3,11 +3,10 @@
 import math
 from typing import Literal, TypeAlias
 
-import numpy
-import numpy.typing
 import matplotlib.cm
-from PIL import Image
+import numpy
 from numpy.typing import NDArray
+from PIL import Image
 
 
 BorderMethod: TypeAlias = Literal['fill_zeros', 'fill_ones', 'edge_repeat', 'mirror_edge', 'wrap_around']

--- a/source/backend/virelay/model.py
+++ b/source/backend/virelay/model.py
@@ -1,17 +1,17 @@
 """Contains the data model abstraction."""
 
+import glob
+import json
 import os
 import re
-import json
-import glob
 from dataclasses import dataclass
-from typing import Literal, TypeAlias, overload, TypedDict
+from typing import Literal, overload, TypeAlias, TypedDict
 
-import yaml
 import h5py
 import numpy
-from PIL import Image
+import yaml
 from numpy.typing import NDArray
+from PIL import Image
 
 from virelay.image_processing import add_border, center_crop, render_heatmap, render_superimposed_heatmap
 

--- a/source/backend/virelay/server.py
+++ b/source/backend/virelay/server.py
@@ -1,24 +1,24 @@
 """Represents the server of ViRelAy, which contains the backend REST API and serves the frontend web app."""
 
+import functools
 import io
 import logging
-import traceback
 import threading
-import functools
+import traceback
 import webbrowser
+from importlib.resources import as_file, files
 from typing import Any, BinaryIO, cast
-from importlib.resources import files, as_file
 
-import numpy
 import flask
 import flask_cors
-from PIL import Image
-from numpy.typing import NDArray
+import numpy
 from flask.typing import RouteCallable
-from typing_extensions import TypedDict, NotRequired
+from numpy.typing import NDArray
+from PIL import Image
+from typing_extensions import NotRequired, TypedDict
 
-from virelay.model import Workspace
 from virelay.image_processing import render_heatmap
+from virelay.model import Workspace
 
 
 class Server:

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,21 +1,21 @@
 """Contains the fixtures that are needed for the unit tests."""
 
-import os
 import json
+import os
 import random
 from typing import Iterator
 
-import yaml
 import h5py
 import numpy
 import pytest
-from PIL import Image
-from pytest import TempPathFactory
+import yaml
 from flask import Flask
 from flask.testing import FlaskClient
+from PIL import Image
+from pytest import TempPathFactory
 
-from virelay.server import Server
 from virelay.model import Workspace
+from virelay.server import Server
 
 NUMBER_OF_CLASSES = 3
 NUMBER_OF_SAMPLES = 40

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -1,25 +1,25 @@
 """Contains the tests for the model abstractions of ViRelAy."""
 
-import os
 import glob
+import os
 
 import h5py
 import numpy
 import pytest
 
 from virelay.model import (
-    DownSamplingMethod,
-    Project,
-    AttributionDatabase,
-    Attribution,
-    AnalysisDatabase,
     Analysis,
     AnalysisCategory,
+    AnalysisDatabase,
+    Attribution,
+    AttributionDatabase,
+    DownSamplingMethod,
     Hdf5Dataset,
     ImageDirectoryDataset,
-    Sample,
-    LabelMap,
     Label,
+    LabelMap,
+    Project,
+    Sample,
     UpSamplingMethod,
     Workspace
 )

--- a/tests/unit_tests/test_server.py
+++ b/tests/unit_tests/test_server.py
@@ -1,16 +1,16 @@
 """Contains the tests for the REST server of ViRelAy."""
 
-import os
-import io
-import re
 import glob
+import io
+import os
+import re
 
 import numpy
-from PIL import Image
 from flask import Flask
 from flask.testing import FlaskClient
+from PIL import Image
 
-from virelay.server import http_ok, http_bad_request, http_not_found, send_image_file, format_exception
+from virelay.server import format_exception, http_bad_request, http_not_found, http_ok, send_image_file
 
 NUMBER_OF_CLASSES = 3
 NUMBER_OF_SAMPLES = 40


### PR DESCRIPTION
They Python imports are now categorized by standard library imports, third-party library imports, and local imports, each separated by a blank line. Each category is sub-categorized into regular imports and "from-imports", which are not separated by blank lines. Each sub-category is sorted alphabetically. Both the imports of the `virelay` package and the imports of the unit tests in the `tests` package were sorted.

Closes issue #103.