### PR TITLE
Fixed the Usage of uv in the tox Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,14 @@
   - The configuration for the HTML-Validate linter was converted to a Node.js package, so that it is easier to use and maintain.
   - The configurations for PyTest and Coverage.py were extracted from the tox configuration file and placed into their own files in the `tests/unit_tests` directory.
   - All references to the old configuration files in the `tests/config` directory have been updated to point to the new locations.
+- Fixed the Usage of uv in the tox Configuration
+  - A major problem in the tox configuration was fixed. Previously, tox-uv was always using the system Python version instead of the Python versions installed via uv. This meant that the Python versions specified in the environment names and the `base_python` option were ignored. This meant that the unit tests were not run with the correct Python version and the environments that used the `base_python` option were not created with the correct Python version. Previously, a fix was attempted by setting the `uv_python_preference` to `only-managed`, but this was not the entire solution. What finally fixed the issue was to always use the commands directly instead of running them through the `uv run` command.
 
 ### Backend REST API Updates in v1.0.0
 
 - Sorted the Python imports. They are now categorized by standard library imports, third-party library imports, and local imports, each separated by a blank line. Each category is sub-categorized into regular imports and "from-imports", which are not separated by blank lines. Each sub-category is sorted alphabetically. Both the imports of the `virelay` package and the imports of the unit tests in the `tests` package were sorted.
 - Converted the `dev-dependencies` section in the `pyproject.toml` file to a `dependency-groups` section, which is the new way to define dependencies, which is standardized across all Python tools. The `dev-dependencies` section was deprecated and will be removed in the future. Separate dependency groups were created for the testing, linting, and documentation dependencies. The `dev` dependency group includes all other dependency groups, so that the `dev` group can be used to install all dependencies at once.
+- The fix to the tox configuration caused some problems with the MyPy configuration to emerge: MyPy could not find the type information for PyTest and Sphinx. This was fixed by adding the `pytest-mypy` package and ignoring the `sphinx` package in the MyPy configuration.
 
 ## v0.6.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ linting = [
     "pycodestyle>=2.13.0,<3.0.0",
     "pydoclint>=0.6.5,<1.0.0",
     "mypy>=1.15.0,<2.0.0",
+    "pytest-mypy>=1.0.1,<2.0.0",
     "types-Flask-Cors>=5.0.0.20240902,<6.0.0",
     "types-PyYAML>=6.0.12.20250402,<7.0.0"
 ]

--- a/tests/linters/.mypy.ini
+++ b/tests/linters/.mypy.ini
@@ -20,6 +20,11 @@ ignore_missing_imports = true
 ignore_missing_imports = true
 
 
+# The Sphinx package does not have type stubs or a py.typed marker
+[mypy-sphinx.*]
+ignore_missing_imports = true
+
+
 # The CoRelAy package does not have type stubs or a py.typed marker
 [mypy-corelay.*]
 ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands_pre =
     npm --prefix "source/frontend" install
     npm --prefix "source/frontend" run build
 commands =
-    uv run pytest \
+    python -m pytest \
         --config-file "tests/unit_tests/.pytest.ini" \
         --cov virelay \
         --cov-config "tests/unit_tests/.coveragerc" \
@@ -48,9 +48,9 @@ depends =
     py313
 commands_pre =
 commands =
-    uv run coverage combine \
+    coverage combine \
         --rcfile "tests/unit_tests/.coveragerc"
-    uv run coverage report \
+    coverage report \
         --rcfile "tests/unit_tests/.coveragerc" \
         --show-missing
     coverage html \
@@ -59,11 +59,11 @@ commands =
 
 # A test environment that will build the documentation using Sphinx
 [testenv:docs]
-base_python = python3.13.2
+base_python = py313
 dependency_groups = docs
 commands_pre =
 commands =
-    uv run sphinx-build \
+    sphinx-build \
         --color \
         --fail-on-warning \
         --fresh-env \
@@ -74,16 +74,19 @@ commands =
         "docs/build" \
         {posargs}
 
-# A test environment that will run the PyLint linter on the REST API backend, the unit tests, the Sphinx configuration file, and the examples
+# A test environment that will run the PyLint linter on the ViRelAy backend, the unit tests, the Sphinx configuration file, and the examples; PyLint
+# not only requires the linting dependency group, but also the testing and the docs dependency groups to be installed, because PyLint will try to
+# import the packages in the modules its it linting, and the unit tests use the PyTest package and the Sphinx configuration uses the PybTeX and the
+# Sphinx packages
 [testenv:pylint]
-base_python = python3.13.2
+base_python = py313
 dependency_groups =
     testing
     linting
     docs
 commands_pre =
 commands =
-    uv run pylint \
+    pylint \
         --rcfile="tests/linters/.pylintrc" \
         --output-format="parseable" \
         "source/backend/virelay" \
@@ -110,11 +113,11 @@ commands =
 
 # A test environment that will run the PyCodeStyle linter on the REST API backend, the unit tests, the setup script, and the Sphinx configuration file
 [testenv:pycodestyle]
-base_python = python3.13.2
+base_python = py313
 dependency_groups = linting
 commands_pre =
 commands =
-    uv run pycodestyle \
+    pycodestyle \
         --config="tests/linters/.pycodestyle" \
         "source/backend/virelay" \
         "tests/unit_tests" \
@@ -140,11 +143,11 @@ commands =
 # A test environment that will run the PyDocLint docstring linter on the REST API backend, the unit tests, the setup script, and the Sphinx
 # configuration file
 [testenv:pydoclint]
-base_python = python3.13.2
+base_python = py313
 dependency_groups = linting
 commands_pre =
 commands =
-    uv run pydoclint \
+    pydoclint \
         --config="tests/linters/.pydoclint.toml" \
         "source/backend/virelay" \
         "tests/unit_tests" \
@@ -170,11 +173,11 @@ commands =
 # A test environment that will run the MyPy static type checker on the REST API backend, the unit tests, the setup script, and the Sphinx
 # configuration file
 [testenv:mypy]
-base_python = python3.13.2
+base_python = py313
 dependency_groups = linting
 commands_pre =
 commands =
-    uv run mypy \
+    mypy \
         --config-file="tests/linters/.mypy.ini" \
         "source/backend/virelay" \
         "tests/unit_tests" \

--- a/uv.lock
+++ b/uv.lock
@@ -1061,6 +1061,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-mypy"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "mypy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/50/3ce149b469e27848c1dc354553b17774f9dde0140625f5a4130bd21e1052/pytest_mypy-1.0.1.tar.gz", hash = "sha256:3f5fcaff75c80dccc6b68cf5ecc28e1bbe71e95309469eb7a28bf408ce55c074", size = 15975, upload-time = "2025-04-02T19:31:16.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/93/25ed3c02e15c4ef1b04cbda7c708ffc5da755986aaacfb48db1f9e84a996/pytest_mypy-1.0.1-py3-none-any.whl", hash = "sha256:ad7133c9b92c802e032f2596590ebede7eea7c418e61d60d5cdd571b55c72056", size = 8701, upload-time = "2025-04-02T19:31:14.914Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1533,6 +1547,7 @@ dev = [
     { name = "pylint" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-mypy" },
     { name = "sphinx" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-new-tab-link" },
@@ -1557,6 +1572,7 @@ linting = [
     { name = "pycodestyle" },
     { name = "pydoclint" },
     { name = "pylint" },
+    { name = "pytest-mypy" },
     { name = "types-flask-cors" },
     { name = "types-pyyaml" },
 ]
@@ -1590,6 +1606,7 @@ dev = [
     { name = "pylint", specifier = ">=3.3.6,<4.0.0" },
     { name = "pytest", specifier = ">=8.3.5,<9.0.0" },
     { name = "pytest-cov", specifier = ">=6.1.1,<7.0.0" },
+    { name = "pytest-mypy", specifier = ">=1.0.1,<2.0.0" },
     { name = "sphinx", specifier = ">=8.1.3,<9.0.0" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2,<1.0.0" },
     { name = "sphinx-new-tab-link", specifier = ">=0.8.0,<1.0.0" },
@@ -1614,6 +1631,7 @@ linting = [
     { name = "pycodestyle", specifier = ">=2.13.0,<3.0.0" },
     { name = "pydoclint", specifier = ">=0.6.5,<1.0.0" },
     { name = "pylint", specifier = ">=3.3.6,<4.0.0" },
+    { name = "pytest-mypy", specifier = ">=1.0.1,<2.0.0" },
     { name = "types-flask-cors", specifier = ">=5.0.0.20240902,<6.0.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250402,<7.0.0" },
 ]


### PR DESCRIPTION
A major problem in the tox configuration was fixed. Previously, tox-uv was always using the system Python version instead of the Python versions installed via uv. This meant that the Python versions specified in the environment names and the `base_python"`option were ignored. This meant that the unit tests were not run with the correct Python version and the environments that used the `base_python` option were not created with the correct Python version. Previously, a fix was attempted by setting the `uv_python_preference` to `only-managed`, but this was not the entire solution. What finally fixed the issue was to always use the commands directly instead of running them through the `uv run` command.

Also, some problems with the MyPy configuration now emerged: MyPy could not find the type information for PyTest and Sphinx. This was fixed by adding the `pytest-mypy` package and ignoring the `sphinx` package in the MyPy configuration.

Closes issue #104.